### PR TITLE
Add code of conduct, contributing and security

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+## Purpose
+
+This project is part of the [WE BUILD](https://www.webuildconsortium.eu/) Large Scale Pilot, co-funded by the European Union, and brings together participants from diverse organisations, countries, and backgrounds. This Code of Conduct establishes expectations for respectful and productive collaboration in all project spaces.
+
+## Expected behaviour
+
+- Communicate respectfully and professionally, recognising that participants come from different cultures, organisations, and areas of expertise.
+- Provide constructive, specific feedback focused on the work rather than the person.
+- Approach disagreements in good faith and seek consensus through technical discussion.
+- Respect the time and contributions of others, including maintainers and reviewers.
+- Credit the work and ideas of others appropriately.
+
+## Unacceptable behaviour
+
+- Harassment, intimidation, or discrimination of any kind.
+- Personal attacks or insults.
+- Sustained disruption of discussions or review processes.
+- Any conduct that would reasonably be considered inappropriate in a professional setting.
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including GitHub issues, pull requests, discussions, and any events or communications related to this project.
+
+## Enforcement
+
+Instances of unacceptable behaviour may be reported by opening a GitHub issue or by contacting the project maintainers directly. All reports will be reviewed and investigated promptly. Maintainers are committed to maintaining confidentiality with regard to the reporter. Appropriate action will be taken, which may include warnings, temporary restrictions, or permanent removal from the repository or consortium.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to WE BUILD Attestation Rulebooks and Schemas
+
+We welcome contributions that improve clarity, correctness, and coverage of rulebooks and schemas. This guide explains how to get involved.
+
+## Getting started
+
+1. **Fork** the repository and clone it locally.
+2. Create a feature branch from `main`:
+   - Branch name suggestion: `feat/<area>-<short-description>` or `fix/<area>-<short-description>`.
+3. Make your changes (see sections below).
+4. Validate your changes locally before opening a pull request.
+
+## Rulebook contributions
+
+- Edit or add Markdown files under `rulebooks/`.
+- Use the [EUDI-template.md](rulebooks/EUDI-template.md) as a starting point for new rulebooks.
+- Keep terminology consistent with EUDI specifications and the existing rulebooks.
+- Use RFC 2119 keywords (`SHALL`, `SHOULD`, `MAY`, etc.) for normative requirements.
+- Follow the standard section structure: Introduction, Document Scope, Document Structure, Keywords, Terminology, and numbered chapters.
+
+## Schema contributions
+
+- Update or add JSON Schema files under `data-schemas/`. Schemas are organised by format (e.g. `sd-jwt/`, `mdoc/`).
+- Use the naming convention: `ds###-<name>-<format>.json` (e.g. `ds001-ebw-oid-sd-jwt.json`).
+- Include at least one representative sample under the corresponding `sample-data/` folder, named `ds###-<name>-<format>-sample.json`.
+- Use JSON Schema Draft-07 or later and include `$schema`, `$id`, `title`, `description`, `type`, and `version` properties.
+
+## Validation
+
+The repository includes a GitHub Actions workflow ([validate-schemas.yml](.github/workflows/validate-schemas.yml)) that automatically validates schemas and samples on every pull request. Before opening a PR:
+
+1. Ensure all JSON files are well-formed.
+2. Verify your sample data conforms to its schema using any JSON Schema validator (e.g. `jsonschema` for Python, `ajv` for Node.js).
+3. Check that every schema has at least one matching sample in the same folder (matched by the `ds###` file prefix).
+
+## Pull request process
+
+1. **Open a pull request** against `main`.
+2. Describe the intent and scope of your change, and reference any related issues or external specifications.
+3. The CI workflow will run automatically — ensure all checks pass.
+4. Be responsive to review comments and iterate as needed until approval.
+
+## Style and conventions
+
+- **British English** spelling is preferred.
+- Use **lowercase with hyphens** for file and folder names.
+- Write **clear commit messages** with context and rationale.
+- Keep changes **scoped and focused** — separate unrelated updates into different PRs.
+- Prefer **additive changes**; avoid breaking changes unless necessary and clearly justified.
+
+## Licence
+
+This project is licensed under the [Apache Licence, Version 2.0](LICENCE). By contributing, you agree that your contributions will be licensed under the same terms.

--- a/README.md
+++ b/README.md
@@ -17,29 +17,7 @@ This repository is intended for implementers, partners, and reviewers who need t
 For the official production rulebooks beyond WE BUILD, see the [EUDI Wallet – Attestation Rulebooks Catalog](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog).
 
 ## How to contribute
-We welcome contributions that improve clarity, correctness, and coverage of rulebooks and schemas. To contribute:
-
-1. Fork the repository and create a feature branch:
-   - Branch name suggestion: `feat/<area>-<short-description>` or `fix/<area>-<short-description>`.
-2. Make your changes:
-   - For rulebooks: edit or add Markdown files under `rulebooks/` and keep terminology consistent with EUDI specifications.
-   - For schemas: update or add JSON Schema files under `data-schemas/` and include at least one representative example under the corresponding `sample-data/` folder.
-   - For samples: add minimal, realistic examples that pass schema validation.
-3. Validate your changes locally (recommended):
-   - Ensure JSON files are well‑formed.
-   - If you introduce a schema, verify your sample(s) conform to it using any JSON Schema validator of your choice.
-4. Open a Pull Request (PR):
-   - Describe the intent and scope of your change and reference any related issues or external specs.
-   - The repository includes a GitHub Actions workflow (`.github/workflows/validate-schemas.yml`) that will run basic checks on JSON files and schemas. Please ensure the checks pass.
-5. Address review feedback:
-   - Be responsive to comments and iterate as needed until approval.
-
-### Contribution guidelines and tips
-- Keep changes scoped and focused; separate unrelated updates into different PRs.
-- Prefer additive changes when possible; avoid breaking changes unless necessary and clearly justified.
-- Use clear commit messages and include context and rationale when updating rulebooks.
-- Maintain consistency in file naming (lowercase with hyphens) and folder placement.
-- British English spelling is preferred.
+We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get started.
 
 ## Funding
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in this project, please report it through [GitHub Security Advisories](https://github.com/webuild-consortium/eudi-wallet-rulebooks-and-schemas/security/advisories/new). This ensures your report is handled privately and responsibly.
+
+**Do not open a public issue for security vulnerabilities.**
+
+## What to include
+
+When reporting a vulnerability, please provide:
+
+- A clear description of the issue.
+- Steps to reproduce the vulnerability, if applicable.
+- The affected files, schemas, or components.
+- The potential impact (e.g. data exposure, schema bypass, trust model weakness).
+
+## What counts as a security issue
+
+In the context of this project, security issues may include:
+
+- Schema design flaws that could allow invalid or malicious data to pass validation.
+- Issues that could undermine the trust model or integrity of credential data.
+- Exposure of sensitive information through sample data or documentation.
+
+## Response process
+
+- We aim to acknowledge reports within **5 working days**.
+- We will work with you to understand and validate the issue.
+- Fixes will be applied to the `main` branch. There is no backporting to previous versions.
+
+## Supported versions
+
+Only the latest version on the `main` branch is actively maintained.


### PR DESCRIPTION
Added contributing, security and code of conduct according to WE BUILD's Github policy. Linked issue: https://github.com/webuild-consortium/webuild-attestation-rulebooks-catalog/issues/33