### PR TITLE
WE BUILD variant of EUDI rulebook

### DIFF
--- a/rulebooks/EUDI-template.md
+++ b/rulebooks/EUDI-template.md
@@ -1,11 +1,16 @@
-* Template version: 1.1, 20-08-2025
+| Version | Date | Description |
+|---------|------------|------------|
+| 0.9 | 02-04-2026 | Copy created from the EUDI attestation rulebook template as the basis for the WE BUILD template. |
+| 1.0 | 02-04-2026 | Added WE BUILD v1 author guidance in Sections 1.1 and 2.1 and introduced Sections 2.8 Code lists and 2.9 Integrity rules. |
 
+# WE BUILD Attestation Rulebook Template for attestations of type *ADD THE ATTESTATION TYPE HERE*
 
-# Attestation Rulebook for attestations of type *ADD THE ATTESTATION TYPE HERE*
+*This WE BUILD v1 template is derived from the EUDI attestation rulebook template and keeps its
+main chapter structure while adding practical author guidance and reusable placeholders.*
 
 *Provide information about the author(s) of this Rulebook in the following form:*
 
-* Author(s): 
+* Author(s):
     * [NAME SURNAME, AFFILIATION]
     * [NAME SURNAME, AFFILIATION]
 * Previous Authors
@@ -14,251 +19,329 @@
 
 *Provide versioning information about the Rulebook in the following form:*
 
-| Version          | Date               | Description                            |
-|------------------|--------------------|----------------------------------------|
+| Version | Date | Description |
+|---------|------------|------------|
 | [VERSION NUMBER] | [PUBLICATION DATE] | [DESCRIPTION OR LINK TO THE CHANGELOG] |
 | [VERSION NUMBER] | [PUBLICATION DATE] | [DESCRIPTION OR LINK TO THE CHANGELOG] |
 
 *Provide a contact email address and/or a link to an issue tracking system that can be used for
-providing feedback, e.g.:* 
+providing feedback, e.g.:*
 
 **Feedback:**
-  *  https://example.com/tracker 
+
+* <https://example.com/tracker>
 
 ## 1 Introduction
 
 ### 1.1 Document scope and purpose
 
-*Provide a concise explanation of the purpose of the defined attestation type, explicitly stating 
+*Provide a concise explanation of the purpose of the defined attestation type, explicitly stating
 why it exists and what its primary objective is within the context of the EUDI Wallet ecosystem*
 
-[RULEBOOK AUTHOR TO DEFINE] 
+*In addition, authors SHOULD describe the attestation in plain language so that readers can quickly
+understand what it does in practice, who it is for, and in which use case(s) it is expected to be
+used. Content may be reused and refined from an existing attestation description where available.*
+
+*When drafting this section, authors SHOULD cover at least the following points:*
+
+* What real-world fact, entitlement, role, status, or capability the attestation expresses.
+* Which issuers, holders, and relying parties are expected to use it.
+* Which use case or user journey the attestation supports.
+* Which existing attestation description, use-case document, or functional specification can be
+used as a source for copy-paste or refinement.
+* Which terminology should remain aligned with the source attestation description.
+
+[RULEBOOK AUTHOR TO DEFINE]
+
+> Example
+>
+> This attestation enables a relying party to verify, in plain language, that the holder is
+> authorised to act in a specific project role. It is intended for project operators, service
+> providers, and supervisory relying parties in the WE BUILD ecosystem. The functional description
+> and actor terminology can be reused from the corresponding use-case attestation description and
+> refined here into rulebook language.
 
 ### 1.2 Document structure
 
 *Provide a brief overview of the Rulebook's sections and their purpose. The main
 sections of the Rulebook SHOULD be*
 
-- Chapter 2, which describes the attestation attributes and metadata in an 
-encoding-independent manner. 
-- Chapter 3, which specifies how the attestation
+* Chapter 2, which describes the attestation attributes and metadata in an
+encoding-independent manner.
+* Chapter 3, which specifies how the attestation
 attributes and metadata are encoded in case the attestation complies with [ISO/IEC
-18013-5] and/or [SD-JWT VC] and/or [W3C VCDM v2.0]. Each encoding SHALL be specified in a separate section or even in a separate chapter.
-- Chapter 4, which specifies attestation usage.
-- Chapter 5, which defines trust anchors
-- Chapter 6, which defines revocation mechanisms
-- Chapter 7, which provides compliance information
+18013-5] and/or [SD-JWT VC] and/or [W3C VCDM v2.0]. Each encoding SHALL be specified in a separate section, or even in a separate chapter.
+* Chapter 4, which specifies attestation usage.
+* Chapter 5, which defines how trust anchors for attestation verification can be obtained.
+* Chapter 6, which defines attestation revocation mechanisms.
+* Chapter 7, which provides compliance information.
 
-### 1.3 Keywords
+### 1.3 Key words
 
 *The following are the recommended keywords. Modify if necessary*
 
-This document uses the capitalised keywords 'SHALL', 'SHOULD' and 'MAY' as
-specified in [RFC 2119], i.e. to indicate requirements, recommendations and
+This document uses the capitalised key words 'SHALL', 'SHOULD' and 'MAY' as
+specified in [RFC 2119], i.e., to indicate requirements, recommendations and
 options specified in this document.
 
 In addition, 'must' (non-capitalised) is used to indicate an external
-constraint, i.e. a requirement that is not mandated by this document, but, for
+constraint, i.e., a requirement that is not mandated by this document, but, for
 instance, by an external document. The word 'can' indicates a capability,
 whereas other words, such as 'will', and 'is' or 'are' are intended as
 statements of fact.
 
 ### 1.4 Terminology
 
-*It is recommended to use the terminology defined in Annex 1 of ARF. For example,
-the following text can be used.* 
+*It is recommended to use the terminology defined in Annex 1 of ARF. For example
+the following text can be used.*
 
 This document uses the terminology specified in Annex 1 of the ARF.
 
 ## 2 Attestation attributes and metadata
 
-*This section is used for defining all attributes that an
+### Chapter overview and requirements
+
+*This chapter is used for defining all attributes that an
 attestation of the defined type may contain. In this section
-the attributes SHALL be defined in an encoding-independent manner (see ARB_06 in [Topic 12]). 
-Each attribute can be mandatory, optional, or conditional, 
-and it SHALL be specified in the corresponding section (see ARB_09 in [Topic 12]).*
+the attributes SHALL be defined in an encoding-independent manner (see ARB_06 in [Topic 12]).
+Each attribute can be mandatory, optional, or conditional
+and this SHALL be specified in the corresponding section (see ARB_09 in [Topic 12]).*
 
 *When attributes are defined, referring to attributes that
-already exist in a catalogue of attestation attributes 
+already exist in a catalogue of attestation attributes
 SHOULD be considered (see ARB_07 in [Topic 12]).*
 
+*Where use-case documentation or an attestation description already defines attribute meanings,
+logical models, code lists, or integrity constraints, authors SHOULD align terminology with those
+sources and may copy and refine that material for this Rulebook.*
+
 *[Topic 12] of Annex 2 of the ARF defines the following High-Level Requirements with
-respect to the Attestation Rulebooks*
+respect to the Attestation Rulebooks:*
 
 **Requirements for QEAA**
-* An attribute as meant in Annex V point a) of the [European Digital Identity Regulation] 
-SHALL be included (see ARB_11 in [Topic 12]). See also section 2.1. 
-* One or more attributes or metadata representing the set of data meant in Annex 
+
+* An attribute as meant in Annex V point a)  of the [European Digital Identity Regulation]
+SHALL be included (see ARB_11 in [Topic 12]). See also section 2.1.
+* One or more attributes or metadata representing the set of data meant in Annex
 V point b) of the [European Digital Identity Regulation] SHALL be included (see ARB_13 in [Topic 12])
 * One or more attributes representing the set of data meant in Annex V point c)  
 of the [European Digital Identity Regulation] SHALL be included (see ARB_16 in [Topic 12]).
-* One or more attributes or metadata representing the set of data meant in Annex V point e) 
+* One or more attributes or metadata representing the set of data meant in Annex V point e)
 of the [European Digital Identity Regulation] SHALL be included (see ARB_18 in [Topic 12]).
 * One or more attributes or metadata representing the location meant in Annex V point h)
-of the [European Digital Identity Regulation] SHALL be included. This location SHALL 
+of the [European Digital Identity Regulation] SHALL be included. This location SHALL
 indicate at least the URL at which a machine-readable version of the trust anchor to be
-used for verifying the QEAA can be found or looked up (see ARB_20 in [Topic 12])
+used for verifying the QEAA can be found or looked up (see ARB_20 in [Topic 12]).
 
 **Requirements for PuB-EAA**
-* Αn attribute as meant in Annex VII point a) of the [European Digital Identity Regulation] 
+
+* An attribute as meant in  Annex VII point a) of the [European Digital Identity Regulation]
 SHALL be included (see ARB_11 in [Topic 12]). See also section 2.1.
-* Οne or more attributes or metadata representing the set of data meant in Annex
+* One or more attributes or metadata representing the set of data meant in Annex
  VII point b) of the [European Digital Identity Regulation] SHALL be included (see ARB_14 in [Topic 12]).
-* Οne or more attributes representing the set of data meant in Annex VII point c) 
+* One or more attributes representing the set of data meant in Annex VII point c)
 of the [European Digital Identity Regulation] SHALL be included (see ARB_16 in [Topic 12]).
-* Οne or more attributes or metadata representing the set of data meant in Annex VII point e)
+* One or more attributes or metadata representing the set of data meant in Annex VII point e)
 of the [European Digital Identity Regulation] SHALL be included (see ARB_18 in [Topic 12]).
 * one or more attributes or metadata representing the location meant in Annex VII point h)
-of the [European Digital Identity Regulation] SHALL be included. This location SHALL 
-indicate at least the URL at which a machine-readable version of the qualified 
-certificate that signed the PuB-EAA can be found or looked up. (see ARB_20 in [Topic 12]) 
+of the [European Digital Identity Regulation] SHALL be included. This location SHALL
+indicate at least the URL at which a machine-readable version of the qualified
+certificate that signed the PuB-EAA can be found or looked up. (see ARB_20 in [Topic 12])
 
 **Requirements for non-qualified EAA**
+
 * An attribute indicating that the attestation is an EAA should be included (see ARB_12 in [Topic 12]).
 See also section 2.1.
-* Οne or more attributes or metadata representing the set of data meant in Annex 
+* One or more attributes or metadata representing the set of data meant in Annex
 V point b) of the [European Digital Identity Regulation] SHALL be included (see ARB_15 in [Topic 12]).
-* Οne or more attributes representing the set of data meant in Annex V point c) of the 
+* One or more attributes representing the set of data meant in Annex V point c) of the
 [European Digital Identity Regulation] SHOULD be included (see ARB_17 in [Topic 12])
-* Οne or more attributes representing the set of data meant in Annex V point e) of 
+* One or more attributes representing the set of data meant in Annex V point e) of
 the [European Digital Identity Regulation] SHOULD be defined (see ARB_19 in [Topic 12]).
- * Οne or more attributes or metadata representing the location at which a machine-readable 
+* One or more attributes or metadata representing the location at which a machine-readable
 version of the trust anchor to be used for verifying the EAA can be found or
-looked up SHOULD be defined. What this location indicates precisely is dependent 
-on the nature of the mechanism used for distributing trust anchors, detailed in section 
+looked up SHOULD be defined. What this location indicates precisely is dependent
+on the nature of the mechanism used for distributing trust anchors, detailed in section
 5 (see ARB_21 in [Topic 12])
 
 ### 2.1 Introduction
 
-*Briefly introduce the overall design and purpose of the specific attestation type 
-defined by this Rulebook, including key decisions regarding its attributes and 
-legal categorisation.* 
+*In this section, briefly introduce the overall design and purpose of the specific attestation type
+defined by this Rulebook, including key decisions regarding its attributes and
+legal categorization.*
 
-*According to Annex V point a) and Annex VII point a) of the [European Digital Identity Regulation]
-an indication, at least in a form suitable for automated processing, that the attestation 
+*According to Annex V point a) and  Annex VII point a) of the [European Digital Identity Regulation]
+an indication, at least in a form suitable for automated processing, that the attestation
 has been issued as a QEAA or Pub-EAA SHALL be defined. Similarly, according to ARB_12
-of [Topic 12] of Annex 2 of the ARF, a similar indication SHOULD be defined for non-qualified EAA.
+of [Topic 12] of Annex 2 of the ARF a similar indication SHOULD be defined for non-qualified EAA.
+
 This document defines the attribute "attestation_legal_category" which SHALL have
-the value "QEAA" or "PuB-EAA" or "non-qualified-EAA".* 
+the value "QEAA" or "PuB-EAA" or "non-qualified-EAA".*
 
-*In the following subsections define in an encoding independent manner all 
+*For complex attestations, authors SHOULD include or reference a logical model, diagram, or similar
+representation that explains the main entities, relationships, and attribute groupings. Such models
+may often be reused from an existing attestation description or use-case documentation.*
+
+> Example
+>
+> The attestation description for Use Case X already contains a domain model showing the holder,
+> issuer, project, permit, and validity period. That model may be copied here and adjusted so that
+> the terminology exactly matches the rulebook.
+
+*In the following subsections 2.2 - 2.7 define in an encoding independent manner all
 mandatory, optional, and conditional attributes and metadata. In each subsection
-provide a table of the following form:*
+provide a table of the following form. When applicable, use Sections 2.8 and 2.9 to document
+code lists and integrity rules that are needed to interpret these attributes consistently:*
 
-| **Data Identifier**                     | **Definition**                                    | **Data type**                                           | **Example value**       |
-|-----------------------------------------|---------------------------------------------------|---------------------------------------------------------|-------------------------|
-| *Provide a unique attribute identifier* | *Briefly describe the semantic of this attribute* | *Provide a type, e.g., integer, string, boolean, date.* | *Give an example value* |
+| **Data Identifier** | **Definition** |**Data type** |**Example value** |
+|------------------------|--------------|--------------|--------------|
+| *Provide a unique attribute identifier* | *Briefly describe the semantic of this attribute*|*Provide a type, e.g., integer, string, boolean, date.*|*Give an example value* |
 
-*NOTE Data identifiers should be unambiguous, machine-readable where possible, and 
+*NOTE Data identifiers should be unambiguous, machine-readable where possible, and
 avoid natural-language ambiguities.*
-
 
 ### 2.2 Mandatory attributes
 
-| **Data Identifier** | **Definition**          | **Data type**     | **Example value** |
-|---------------------|-------------------------|-------------------|-------------------|
-| *Provide a value*   | *Provide succinct text* | *Provide a value* | *Provide a value* |
-
+| **Data Identifier** | **Definition** |**Data type** |**Example value** |
+|------------------------|--------------|--------------|--------------|
+| *Provide a value* | *Provide succinct text*|*Provide a value*|*Provide a value* |
 
 ### 2.3 Optional attributes
 
-| **Data Identifier** | **Definition**          | **Data type**     | **Example value** |
-|---------------------|-------------------------|-------------------|-------------------|
-| *Provide a value*   | *Provide succinct text* | *Provide a value* | *Provide a value* |
+| **Data Identifier** | **Definition** |**Data type** |**Example value** |
+|------------------------|--------------|--------------|--------------|
+| *Provide a value* | *Provide succinct text*|*Provide a value*|*Provide a value* |
 
 ### 2.4 Conditional attributes
 
-| **Data Identifier** | **Definition**          | **Data type**     | **Example value** |
-|---------------------|-------------------------|-------------------|-------------------|
-| *Provide a value*   | *Provide succinct text* | *Provide a value* | *Provide a value* |
+| **Data Identifier** | **Definition** |**Data type** |**Example value** |
+|------------------------|--------------|--------------|--------------|
+| *Provide a value* | *Provide succinct text*|*Provide a value*|*Provide a value* |
 
-### 2.5 Mandatory metadata 
+### 2.5 Mandatory metadata
 
-| **Data Identifier** | **Definition**          | **Data type**     | **Example value** |
-|---------------------|-------------------------|-------------------|-------------------|
-| *Provide a value*   | *Provide succinct text* | *Provide a value* | *Provide a value* |
+| **Data Identifier** | **Definition** |**Data type** |**Example value** |
+|------------------------|--------------|--------------|--------------|
+| *Provide a value* | *Provide succinct text*|*Provide a value*|*Provide a value* |
 
+### 2.6 Optional metadata
 
-### 2.6 Optional metadata 
+| **Data Identifier** | **Definition** |**Data type** |**Example value** |
+|------------------------|--------------|--------------|--------------|
+| *Provide a value* | *Provide succinct text*|*Provide a value*|*Provide a value* |
 
-| **Data Identifier** | **Definition**          | **Data type**     | **Example value** |
-|---------------------|-------------------------|-------------------|-------------------|
-| *Provide a value*   | *Provide succinct text* | *Provide a value* | *Provide a value* |
+### 2.7 Conditional metadata
 
-### 2.7 Conditional metadata 
+| **Data Identifier** | **Definition** |**Data type** |**Example value** |
+|------------------------|--------------|--------------|--------------|
+| *Provide a value* | *Provide succinct text*|*Provide a value*|*Provide a value* |
 
-| **Data Identifier** | **Definition**          | **Data type**     | **Example value** |
-|---------------------|-------------------------|-------------------|-------------------|
-| *Provide a value*   | *Provide succinct text* | *Provide a value* | *Provide a value* |
+### 2.8 Code lists
 
+*Use this section for controlled vocabularies, enumerations, value sets, or external catalogues
+that are necessary to interpret one or more attributes or metadata items. Definitions may be reused
+from the attestation description or other use-case documentation and refined here where needed.*
 
-# 3 Attestation encoding 
+*For each code list, authors SHOULD state the field to which it applies, the allowed values, their
+meaning, the source vocabulary or reference, and any extensibility rule or governance note.*
 
-## 3.1 ISO/IEC 18013-5-compliant encoding 
-*If the attestation type supports the format specified in ISO/IEC 18013-5,
-then in this section the ISO/IEC 18013-5-compliant encoding of attributes and metadata 
-should be defined.* 
+| **Field name** | **Allowed values** | **Meaning** | **Source / vocabulary** | **Notes / extensibility** |
+|----------------|--------------------|-------------|--------------------------|---------------------------|
+| *Provide a field name* | *List the allowed values* | *Explain what each value means* | *Reference the source* | *State whether extensions are allowed* |
 
-*It is noted that (see ARB_02 in [Topic 12]) the Schema Provider SHALL analyse whether it must 
-be possible for a User to present that type of attestation when the Wallet Unit 
-and the Relying Party are in proximity and attestations are presented without 
-using the internet. If so,the attestations must be issued in the ISO/IEC 18013-5-compliant 
+> Example
+>
+> | **Field name** | **Allowed values** | **Meaning** | **Source / vocabulary** | **Notes / extensibility** |
+> |----------------|--------------------|-------------|--------------------------|---------------------------|
+> | `signatory_rule` | `sole`, `joint` | Indicates whether the representative may bind the organisation alone or only together with one or more additional representatives | EUCC attestation description / WE BUILD company representation model | Additional values SHOULD only be introduced if they are defined consistently across issuer and verifier implementations |
+
+### 2.9 Integrity rules
+
+*Use this section to define integrity or consistency rules that are not fully captured by the
+encoding format or schema alone, such as cross-field dependencies, temporal consistency checks,
+mutual exclusivity, or conditional combinations of values.*
+
+*Integrity rules may be copied and refined from an attestation description, logical model, or
+business-rule specification where available.*
+
+| **Rule ID** | **Rule statement** | **Why it exists** | **Where enforced** | **Verifier / issuer behavior on failure** |
+|-------------|--------------------|-------------------|--------------------|-------------------------------------------|
+| *Provide a rule identifier* | *State the rule precisely* | *Explain the rationale* | *Issuer, verifier, schema validation, or business process* | *Describe rejection, warning, or remediation behavior* |
+
+> Example
+>
+> | **Rule ID** | **Rule statement** | **Why it exists** | **Where enforced** | **Verifier / issuer behavior on failure** |
+> |-------------|--------------------|-------------------|--------------------|-------------------------------------------|
+> | `IR-01` | If `legal_representative.natural_person` is present, `full_name` and `date_of_birth` SHALL be present. If `legal_representative.legal_person` is present, `name`, `id`, and `legal_form_type` SHALL be present. | Prevents incomplete representation statements and ensures that a relying party can determine whether the representative is a natural person or a legal person and validate the representation data accordingly. | Issuer business rules, schema validation, and verifier business validation. | Issuer SHALL reject incomplete representative data; verifier SHALL treat the representation information as invalid or insufficient for the transaction. |
+
+# 3 Attestation encoding
+
+## 3.1 ISO/IEC 18013-5-compliant encoding
+
+*If the attestation type supports the the format specified in ISO/IEC 18013-5,
+then in this section the  ISO/IEC 18013-5-compliant encoding of attributes and metadata
+should be defined.*
+
+*It is noted that (see ARB_02 in [Topic 12]) the Schema Provider SHALL analyse whether it must
+be possible for a User to present that type of attestation when the Wallet Unit
+and the Relying Party are in proximity and attestations are presented without
+using the internet. If so,the attestations must be issued in the ISO/IEC 18013-5-compliant
 mdoc format.*
 
-*Furthermore, in this section a document type SHALL be defined, which SHALL be 
+*Furthermore, in this section a document type SHALL be defined, which SHALL be
 unique within the scope of the EUDI Wallet ecosystem (see ARB_05 in [Topic 12]).*
 
 [RULEBOOK AUTHOR TO DEFINE THE ATTESTATION TYPE]
 
-*Provide a list of available encoding formats and their specifications (e.g. encoding, maximum lengths, 
-date formats, etc.). For example:*
+*Provide a list of available encoding formats and their specifications (e.g., encoding, maximum lengths,
+date formats, etc). For example:*
 
-- tstr, uint, bstr, bool and tdate are CDDL representation types defined in
+* tstr, uint, bstr, bool and tdate are CDDL representation types defined in
   [RFC 8610].
-    - Regarding type tstr: this document confirms that, as specified in [RFC
+    * Regarding type tstr: this document confirms that, as specified in [RFC
     8949], a tstr SHALL be encoded in UTF-8 and SHALL support the full Unicode
     range.
-    - All attributes having encoding type tstr SHALL have a maximum length of
+    * All attributes having encoding type tstr SHALL have a maximum length of
     150 characters.
-    - This document specifies full-date as full-date = #6.1004(tstr), where tag
+    * This document specifies full-date as full-date = #6.1004(tstr), where tag
     1004 is specified in [RFC 8943].
-    - In accordance with [RFC 8949], section 3.4.1, a tdate attribute SHALL
+    * In accordance with [RFC 8949], section 3.4.1, a tdate attribute SHALL
     contain a date-time string as specified in [RFC 3339]. In accordance with
     [RFC 8943], a full-date attribute SHALL contain a full-date string as
     specified in [RFC 3339].
-    - The following requirements apply to the representation of dates in
+    * The following requirements apply to the representation of dates in
     attributes, unless otherwise indicated:
-        - Fractions of seconds SHALL NOT be used;
-        - A local offset from UTC SHALL NOT be used; the time-offset defined in
+        * Fractions of seconds SHALL NOT be used;
+        * A local offset from UTC SHALL NOT be used; the time-offset defined in
         [RFC 3339] SHALL be to "Z".
-    - [RFC 8949], section 4.2, describes four rules for canonical CBOR. Three of
+    * [RFC 8949], section 4.2, describes four rules for canonical CBOR. Three of
     those rules SHALL be implemented for all CBOR structures, as
     follows:
-        - integers (major types 0 and 1) SHALL be as small as possible;
-        - the expression of the length in a bstr, tstr, array or map SHALL be as
+        * integers (major types 0 and 1) SHALL be as small as possible;
+        * the expression of the length in a bstr, tstr, array or map SHALL be as
         short as possible;
-        - indefinite-length items SHALL be made into definite-length items.
+        * indefinite-length items SHALL be made into definite-length items.
 
 *This section should include a table the data identifier specified in
-Chapter 2, the corresponding attribute identifier to be used in
-presentation requests and responses according to [ISO/IEC 18013-5] and the encoding 
+Chapter 2,  the corresponding attribute identifier to be used in
+presentation requests and responses according to [ISO/IEC 18013-5] and the encoding
 of each attribute.*
 
 *Additionally, the following rules should be followed:*
 
-* When specifying new attributes, existing conventions 
+* When specifying new attributes, existing conventions
 for attribute identifier values and attribute syntaxes SHOULD
 be considered (see ARB_07 in [Topic 12]).
-* Each attribute SHALL be defined within an attribute namespace. 
-  * An attribute namespace 
-SHALL fully define the identifier, the syntax, and the semantics of each attribute 
-within that namespace. 
-  * An attribute namespace SHALL have an identifier that is 
-unique within the scope of the EUDI Wallet ecosystem, and each attribute 
-identifier SHALL be unique within that namespace (see ARB_06a in [Topic 12]) 
-  * A domestic namespace MAY be defined 
-to specify attributes that are specific to this Rulebook and are not included in 
-the applicable EU-wide or sectoral namespace (see ARB_10 in [Topic 12]). 
+* Each attribute SHALL be defined within an attribute namespace.
+    * An attribute namespace
+SHALL fully define the identifier, the syntax, and the semantics of each attribute
+within that namespace.
+    * An attribute namespace SHALL have an identifier that is
+unique within the scope of the EUDI Wallet ecosystem, and each attribute
+identifier SHALL be unique within that namespace (see ARB_06a in [Topic 12])
+    * A domestic namespace MAY defined
+to specify attributes that are specific to this Rulebook and are not included in
+the applicable EU-wide or sectoral namespace (see ARB_10 in [Topic 12]).
 
 | **Data Identifier** | **Attribute identifier** | **Encoding format** | **Namespace**|
 |------------------------|--------------|------------------|------------------|
@@ -271,22 +354,23 @@ in Section 2.1 SHALL be:*
 |------------------------|--------------|------------------|------------------|
 | attestation_legal_category | attestation_legal_category | tstr |com.example.att.1|
 
-Finally, illustrative examples SHALL be included. 
+Finally, illustrative examples SHALL be included.
 
 [RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF FULL OR PARTIAL mDOC OF THE ATTESTATION]
 
 [RULEBOOK AUTHOR TO PROVIDE THE ATTRIBUTES AND THEIR VALUES INCLUDED IN THE EXAMPLE]
 
-### 3.2 SD-JWT VC-based encoding 
-*If the attestation type supports the format specified in "SD-JWT-based Verifiable 
-Credentials (SD-JWT VC)", then in this section the SD-JWT VC-compliant encoding 
-of attributes and metadata SHALL be defined. It SHALL be ensured that the attestations 
+### 3.2 SD-JWT VC-based encoding
+
+*If the attestation type supports the format specified in "SD-JWT-based Verifiable
+Credentials (SD-JWT VC)", then in this section the SD-JWT VC-compliant encoding
+of attributes and metadata SHALL be defined. It SHALL be ensured that the attestations
 comply with the 'SD-JWT VCs' profile specified in [HAIP] (see ARB_01b in [Topic 12]).*
 
-*It is noted that a Schema Provider MAY specify in the Attestation 
-Rulebook that that type of attestation must be issued in the [SD-JWT VC]-compliant 
-format, provided the [SD-JWT VC] specification has been approved by an EU standardisation 
-body or by the European Digital Identity Cooperation Group established pursuant to 
+*It is noted that a Schema Provider MAY specify in the Attestation
+Rulebook that that type of attestation must be issued in the [SD-JWT VC]-compliant
+format, provided the [SD-JWT VC] specification has been approved by an EU standardisation
+body or by the European Digital Identity Cooperation Group established pursuant to
 Article 46e(1) of the [European Digital Identity Regulation] (see ARB_03 in [Topic 12]).*
 
 *In this section, a Verifiable Credential Type (`vct`) SHALL be defined,
@@ -294,31 +378,28 @@ which SHALL be unique within the scope of the EUDI Wallet ecosystem (see ARB_05 
 
 [RULEBOOK AUTHOR TO DEFINE THE ATTESTATION TYPE]
 
-*Additionally, when specifying new attributes, existing conventions 
+*Additionally, when specifying new attributes, existing conventions
 for attribute identifier values and attribute syntaxes SHOULD
 be considered (see ARB_07 in [Topic 12]).*
 
-*Rulebook authors SHALL ensure that each claim name is either 
-- included in the IANA registry for JWT claims,
-- is a Public Name as defined in [RFC 7519], or
-- or is a Private Name specific to the attestation type. (see ARB_06b in [Topic 12]).*
+*Rulebook authors SHALL ensure that each claim name is either
 
-*For all claims (i.e. all top-level properties, all nested properties, and all array entries), 
+* included in the IANA registry for JWT claims,
+* is a Public Name as defined in [RFC 7519], or
+* or is a Private Name specific to the attestation type. (see ARB_06b in [Topic 12]).*
+
+*For all claims (i.e., all top-level properties, all nested properties, and all array entries),
 the Rulebook SHALL specify whether an Attestation Provider MUST, MAY, or MUST NOT make that
 claim selectively disclosable (see ARB_30 in [Topic 12]).*
 
-*Rulebook authors SHOULD consider defining a Type Metadata Document for the attestation type 
+*Rulebook authors SHOULD consider defining a Type Metadata Document for the attestation type
 specified in the Rulebook, as defined in Chapter 6 of [SD-JWT VC]. If such a document is defined,
-it SHOULD contain the Claim Selective Disclosure Metadata (defined in Section 9.3 of [SD-JWT VC]) 
-for each of the claims, in order to specify if that claim is selectively disclosable (see ARB_31 
+it SHOULD contain the Claim Selective Disclosure Metadata (defined in Section 9.3 of [SD-JWT VC])
+for each of the claims, in order to specify if that claim is selectively disclosable (see ARB_31
 in [Topic 12]).*
 
-*Rulebook authors SHOULD consider defining a JSON Schema for the attestation type specified
-in the Rulebook, as defined in Section 6.5 of [SD-JWT VC], and include or reference that 
-Schema in the Type Metadata Document meant in ARB_31 (see ARB_32 in [Topic 12]).*
-
-*IANA-registered claims should be presented in a table that
-includes their data identifier, attribute identifier, 
+*IANA-registered claims should be presented in table that
+includes their data identifier, attribute identifier,
 encoding format, and reference or note. For example,*
 
 | **Data Identifier** | **Attribute identifier** | **Encoding format** |**Reference/Notes** |**Disclosable**|
@@ -340,8 +421,7 @@ in Section 2.1 SHALL be:*
 |---------------------|--------------------------|---------------------|-----------|---------------|
 | attestation_legal_category | attestation_legal_category | string | Defined in Attestation Rulebook template |MUST NOT|
 
-
-Finally, illustrative examples SHALL be included. 
+Finally, illustrative examples SHALL be included.
 
 [RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF THE JWT CLAIM SET USED BY THE PROVIDER]
 
@@ -350,22 +430,21 @@ Finally, illustrative examples SHALL be included.
 [RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF A HUMAN READABLE VERSION OF THE SD-JWT PAYLOAD
 AND A DESCRIPTION OF THE DISCLOSURES INCLUDED IN THE EXAMPLE]
 
-
-
 ### 3.3 W3C Verifiable Credentials Data Model-based encoding
-*If the attestation type supports the format specified in W3C Verifiable Credentials 
-Data Model, then in this section the corresponding encoding of attributes and 
-metadata should be defined.* 
+
+*If the attestation type supports the the format specified in W3C Verifiable Credentials
+Data Model, then in this section the  corresponding encoding  of attributes and
+metadata should be defined.*
 
 *It is noted that only a a non-qualified EAA can use this format (see ARB_01a in [Topic 12])*
 
 *Tables similar to the ones specified in section 4 SHALL be defined.*
 
-*This section SHALL reference one or more documents specifying in detail how a 
-Relying Party can request attributes from a such an attestation, and how a User 
-can selectively disclose attributes from such an attestation. Moreover, these 
-referenced documents SHALL be approved by an EU standardisation body or by the European 
-Digital Identity Cooperation Group established pursuant to Article 46e(1) of the 
+*This section SHALL reference one or more documents specifying in detail how a
+Relying Party can request attributes from a such an attestation, and how a User
+can selectively disclose attributes from such an attestation. Moreover, these
+referenced documents SHALL be approved by an EU standardisation body or by the European
+Digital Identity Cooperation Group established pursuant to Article 46e(1) of the
 [European Digital Identity Regulation] (see ARB_04 in [Topic 12]).*
 
 *Finally, illustrative examples SHALL be included.*
@@ -375,78 +454,86 @@ Digital Identity Cooperation Group established pursuant to Article 46e(1) of the
 [RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF THE PROOF TYPE]
 
 ## 4 Attestation usage
-*Briefly describe the primary use cases or scenarios for which this attestation 
+
+*Briefly describe the primary use cases or scenarios for which this attestation
 type is intended*
 
-*Additionally, in this section it SHOULD be specified whether a Relying Party receiving the attestation
-must request and verify a PID (see ARB_27 in [Topic 12]). Also, beyond PID verification, 
-it SHOULD be defined what other key obligations a Relying Party has when processing 
-this attestation type (e.g. signature verification, freshness checks)*
+*Additionally, in this section it SHOULD  be specified whether a Relying Party receiving the attestation
+must request and verify a PID (see ARB_27 in [Topic 12]). Also beyond PID verification,
+it SHOULD be defined what other key obligations does a Relying Party have when processing
+this attestation type (e.g., signature verification, freshness checks)*
 
-*Furthermore, provide potential presentation requirements, e.g. are there specific 
-requirements for how this attestation must be presented (e.g. online, offline, specific protocols)?*
+*Furthermore, provide potential presentation requirements, e.g., are there specific
+requirements for how this attestation must be presented (e.g., online, offline, specific protocols)?"*
+
+*Specify whether an attestation of this type SHALL or SHOULD be device-bound or non-device-bound, see ARB_34 in [Topic 12]*
+
+*If an attestation of this type is device-bound, specify if it SHALL, SHOULD or MAY be cryptographically bound to another type of attestation on the same Wallet Unit. If needed (based on this decision), include the attribute `cryptographically_bound_to` defined in ARB_28 as an optional, recommended, or mandatory attribure in [Section 2.5](#26-optional-metadata). If present in an Attestation Rulebook, the identifier for this attribute SHALL be "cryptographically_bound_to" for both ISO/IEC 18013-5 and SD-JWT VC-compliant attestations, and its contents SHALL be a `tstr` or `string` (as applicable) containing an attestation type or vct (see ARB_05). Finally, specify the value of the `tstr` or `string`.* 
+
+*EXAMPLE   In case an attestation type of this type must be bound to a PID, the value of the `tstr` or `string` must be set to "eu.europa.ec.eudi.pid.1" or "urn:eudi:pid:1". Note that it does not matter whether the attestation type or the vct value is used.*
 
 *Finally, in this section information about potential transactional data
-SHALL be defined (see [Topic 20] of Annex 2 of the ARF).*
+SHALL be defined; see [Topic 20] of Annex 2 of the ARF.*
 
 ## 5 Trust anchors
 
 *Mechanisms for the provision of a trust anchor that SHALL
 be used for the verification of an attestation SHALL be defined in this section.*
 
-*It is noted that the ARF specifies the following for QEAAs and Pub-EAAs*
+*It is noted that the ARF specifies the following for QEAAs and Pub-EAAs:*
 
-> To do this for [...] QEAAs the Relying Party Instance uses a trust anchor of 
-the Provider obtained from a Trusted List. Note that the PID Provider or QEAA 
-Provider may use an intermediate signing certificate to sign the PID or 
- attestation and use the trust anchor to sign the signing certificate, instead 
+> To do this for [...] QEAAs the Relying Party Instance uses a trust anchor of
+the Provider obtained from a Trusted List. Note that the PID Provider or QEAA
+Provider may use an intermediate signing certificate to sign the PID or
+attestation, and use the trust anchor to sign the signing certificate, instead
 of signing the PID or attestation directly with the trust anchor.
-
-> For PuB-EAAs, the Relying Party Instance verifies a PuB-EAA by first 
-verifying the signature of the PuB-EAA Provider over the PuB-EAA, using the 
-PuB-EAA Provider certificate issued by a QTSP. Subsequently, the Relying Party 
-Instance verifies the signature over this certificate, using the corresponding 
-trust anchor from the QTSP Trusted List. Note that both the PuB-EAA Provider 
-and the QTSP may use an intermediate signing certificate. All other things 
-being equal, the verification of a PuB-EAA will therefore involve one or more 
+>
+> For PuB-EAAs, the Relying Party Instance verifies a PuB-EAA by first
+verifying the signature of the PuB-EAA Provider over the PuB-EAA, using the
+PuB-EAA Provider certificate issued by a QTSP. Subsequently, the Relying Party
+Instance verifies the signature over this certificate, using the corresponding
+trust anchor from the QTSP Trusted List. Note that both the PuB-EAA Provider
+and the QTSP may use an intermediate signing certificate. All other things
+being equal, the verification of a PuB-EAA will therefore involve one or more
 extra certificates, compared to the verification of a PID or QEAA.
 
-*For non-qualified EAA in this section it SHOULD be defined (see ARB_26 in [Topic 12])
-how the attributes or metadata representing the location at which a machine-readable 
+*For non-qualified EAA in this section it SHOULD  be defined (see ARB_26 in [Topic 12])
+how the attributes or metadata representing the location at which a machine-readable
 version of the trust anchor to be used for verifying the attestation can be found,
 specified in section 2, are used. This includes a detailed description about how
-a Relying Party can obtain the trust anchor, as well as a detailed description about
-how this trust anchor can be used for verifying that the provider is authorised
-to issue the attestation. Additionally, for non-qualified EAA Provider this section
+a Relying Party can obtain the trust anchors, as well as a detailed description about
+how this trust anchor can be used for verifying that the provider is authorized
+to issue the attestation. Additionally, for non-qualified EAA Providers this section
 MAY include a description of mechanisms that can be used by a Wallet Unit for
-verifying that the provider is authorised to issue this type of attestation (see 
+verifying that the provider is authorized to issue this type of attestation (see
 ISSU_34 in [Topic 10])*
 
-
-
-
 ## 6 Revocation
+
 (Refer to [Topic 7] of the ARF for a list of High-Level Requirements related to Revocation)
 
-*In this section information about the revocation mechanism used SHALL be defined.* 
+*In this section information about the revocation mechanism used SHALL be defined.*
 
-*For PID, QEAA, or PuB-EAA it SHALL be defined whether only short-lived attestations 
-will be used, having a validity period of 24 hours or less, such that revocation 
-will never be necessary, or that the attestations are revocable.* 
+*For PID, QEAA, or PuB-EAA it SHALL  be defined whether  only short-lived attestations
+will be used, having a validity period of 24 hours or less, such that revocation
+will never be necessary, or that the attestations are revocable.*
 
 *For revocable attestations it SHALL be defined which of the following methods must be implemented:*
-* Use an Attestation Status List mechanism included in a Technical Specification 
+
+* Use an Attestation Status List mechanism included in a Technical Specification
 that will be specified by the Commission.
-* Use an Attestation Revocation List mechanism included in a Technical Specification 
+* Use an Attestation Revocation List mechanism included in a Technical Specification
 that will be specified by the Commission.
 
 ## 7 Compliance
-*In this section explicitly state how this specific rulebook complies with the 
+
+*In this section explicitly state how this specific rulebook complies with the
 general EUDI framework, ARF, and relevant regulations*
 
-[RULEBOOK AUTHOR TO DEFINE] 
+[RULEBOOK AUTHOR TO DEFINE]
 
 ## 8 References
+
 | **Item Reference** | **Standard name/details**|
 |--------------------|---------------------------|
 | [European Digital Identity Regulation] | [Regulation (EU) 2024/1183](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202401183) of the European Parliament and of the Council of 11 April 2024 amending Regulation (EU) No 910/2014 as regards establishing the European Digital Identity Framework |
@@ -464,12 +551,3 @@ general EUDI framework, ARF, and relevant regulations*
 | [Topic 12] | ARF Annex 2 - Topic 12 - Attestation Rulebooks, Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2312-topic-12-attestation-rulebooks>|
 | [Topic 20] | ARF Annex 2 - Strong User authentication for electronic payments, Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2320-topic-20-strong-user-authentication-for-electronic-payments>|
 | [W3C VCDM v2.0] | Sporny, M. *et al,* Verifiable Credentials Data Model v2.0, W3C Recommendation.  |
-
-
-
-
-
-
-
-
- 


### PR DESCRIPTION
This PR introduces a WE BUILD v1 attestation rulebook template derived from the EUDI template, while keeping the main chapter structure intact as much as possible.

The goal of this first version is to make the template more practical for use case authors by adding a bit more guidance directly in the document itself. In particular, this PR:

adds extra author guidance in Section 1.1, including explicit encouragement to describe the attestation in plain language and to reuse text from existing attestation descriptions where relevant;
adds a prompt in Section 2.1 to include or reuse a logical model/diagram where useful;
adds Section 2.8 for code lists, including a placeholder table and example;
adds Section 2.9 for integrity rules, including a placeholder table and example.