### PR TITLE
Add rulebook naming and structure convention

### DIFF
--- a/rulebooks/README.md
+++ b/rulebooks/README.md
@@ -1,0 +1,58 @@
+# Rulebook conventions
+
+This folder contains the WE BUILD attestation rulebooks. Each rulebook is a self-contained document describing a single attestation type, its data model, and the rules that govern its issuance, presentation, and verification.
+
+This README defines the naming and structure convention for rulebooks in this folder. It applies to all new rulebooks and to migrations of existing ones.
+
+## 1. Folder name pattern
+
+Each rulebook lives in its own folder under `rulebooks/`:
+
+```
+rulebooks/rb-<slug>/
+```
+
+- `rb-` is a constant prefix.
+- `<slug>` is lower-case kebab-case. Where an EUDI ARF attestation slug exists (for example `pid`, `mdl`), match it. Otherwise use a short, consortium-defined name.
+
+Regex: `^rb-[a-z0-9-]+$`
+
+Examples:
+
+- `rb-pid`
+- `rb-mdl`
+- `rb-eucc`
+- `rb-eu-poa`
+- `rb-ereceipt`
+- `rb-organisational-mandate`
+
+## 2. Folder contents
+
+Each rulebook folder contains a single required file:
+
+- `README.md`, the rulebook itself, following the rulebook template at [`rulebooks/EUDI-template.md`](EUDI-template.md).
+
+Authors should not renumber or rename the template's sections. Sections that do not apply to a specific attestation type should be retained with a short note explaining why.
+
+Schemas, samples, machine-readable metadata, and supporting assets are out of scope for this version of the convention. They will be addressed in a follow-up proposal once the per-folder README structure is in place across all rulebooks.
+
+## 3. Governance
+
+- Slugs are agreed in the pull request that introduces the rulebook. If two pull requests propose the same slug, reviewers pick one.
+- Slugs are stable once merged. Renames are allowed via a pull request with a clear reason.
+- This convention retires the previous `dsNNN-` numbering scheme. Gaps in the old numbering and the placement of the Hello World example alongside numbered rulebooks are resolved by switching to slugs.
+
+## 4. Migration of existing rulebooks
+
+Existing rulebooks move into the new structure as follows:
+
+| Current file | New path |
+|---|---|
+| `rulebooks/ds001-ebw-oid-rulebook.md` | `rulebooks/rb-ebw-oid/README.md` |
+| `rulebooks/ds002-pid-rulebook.md` | `rulebooks/rb-pid/README.md` |
+| `rulebooks/ds004-eucc-rulebook.md` | `rulebooks/rb-eucc/README.md` |
+| `rulebooks/ds005-hello-world-rulebook.md` | `rulebooks/rb-hello-world/README.md` |
+| `rulebooks/ds007-eu-poa-rulebook.md` | `rulebooks/rb-eu-poa/README.md` |
+| `rulebooks/rb-ereceipts.md` (in progress) | `rulebooks/rb-ereceipt/README.md` |
+
+The migration itself will be carried out in a separate pull request. Slugs in this table can be revised before the migration lands; once merged, they are stable.

--- a/rulebooks/README.md
+++ b/rulebooks/README.md
@@ -53,6 +53,6 @@ Existing rulebooks move into the new structure as follows:
 | `rulebooks/ds004-eucc-rulebook.md` | `rulebooks/rb-eucc/README.md` |
 | `rulebooks/ds005-hello-world-rulebook.md` | `rulebooks/rb-hello-world/README.md` |
 | `rulebooks/ds007-eu-poa-rulebook.md` | `rulebooks/rb-eu-poa/README.md` |
-| `rulebooks/rb-ereceipts.md` (in progress) | `rulebooks/rb-ereceipt/README.md` |
+| `rulebooks/rb-e-receipt.md` | `rulebooks/rb-e-receipt/README.md` |
 
 The migration itself will be carried out in a separate pull request. Slugs in this table can be revised before the migration lands; once merged, they are stable.


### PR DESCRIPTION
Added `rulebooks/README.md` defining the v1 naming and structure convention for the rulebooks folder.

- Each rulebook lives in its own `rb-<slug>/` directory with a single required `README.md`, following the existing rulebook template.
- Slug pattern: `rb-` prefix plus lower-case kebab-case, regex `^rb-[a-z0-9-]+$`. Where an EUDI ARF slug exists, it is matched.
- Retires the `dsNNN-` numbering scheme, which directly addresses the question raised in #54: gaps in the old numbering and the placement of the Hello World example alongside numbered rulebooks go away.
- Includes a slug mapping table for the existing rulebooks so the migration is mechanical, not a per-file debate.

## Scope

This is the v1 convention, deliberately narrow. Schemas, samples, machine-readable metadata, and migration of `data-schemas/` and `sample-data/` are deferred to a follow-up proposal once the per-folder README structure is in place.

The migration of the existing `dsNNN-*.md` files into `rb-<slug>/README.md` will be carried out in a separate pull request once this convention is agreed.