### PR TITLE
Review Feedback updates

### DIFF
--- a/rulebooks/rb-pid/README.md
+++ b/rulebooks/rb-pid/README.md
@@ -358,7 +358,7 @@ The following Private Names specific to the attestation type defined in this doc
 
 ### 3.2.2 Attribute status
 
-For SD-JWT VC-compliant PIDs, the PID MUST include a `status` claim if the technical validity period is greater than 25 hours. This claim enables Relying Parties to determine if a credential has been revoked via a status list mechanism, as specified in [SD-JWT VC](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/16/).
+For SD-JWT VC-compliant PIDs, the PID MUST include a `status` claim if the technical validity period is greater than 25 hours. This claim enables Relying Parties to determine if a credential has been revoked via a status list mechanism, as specified in [SD-JWT VC].
 
 The `status` claim SHALL be a JSON object with the following members:
 - `type` (string): SHALL be `"status-list"`.
@@ -399,10 +399,7 @@ common EU-wide type as well as on any domestic types is published and
 accessible in a catalog.
 
 
-### 3.3 SD-JWT version 
-For WE BUILD we focus on following the sd-jwt standard draft version 16, [which can be found here](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/16/)
-
-### 3.4 Example
+### 3.3 Example
 
 EXAMPLE: The following example shows the payload of a PID in SD-JWT VC format before the encoding into the SD-JWT format.
 
@@ -593,7 +590,7 @@ Further requirements in this Rulebook comply with or reference the applicable re
 | [ISO/IEC 18013-5]                      | ISO/IEC 18013-5, Personal identification --- ISO-compliant driving licence - Part 5: Mobile driving licence (mDL) application, First edition, 2021-09                                                                                                                    |
 | [OIDC]                                 | Sakimura, N. et al., "OpenID Connect Core 1.0", OpenID Foundation. Available: <https://openid.net/specs/openid-connect-core-1_0.html>                                                                                                                                    | 
 | [EKYC]                                 | OpenID Connect for Identity Assurance Claims Registration <https://openid.net/specs/openid-connect-4-ida-claims-1_0-final.html#ICAO-Doc9303>                                                                                                                             |
-| [SD-JWT VC]                            | SD-JWT-based Verifiable Credentials (SD-JWT VC). Available: <https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/>, version draft-ietf-oauth-sd-jwt-vc-09                                                                                                        |
+| [SD-JWT VC]                            | SD-JWT-based Verifiable Credentials (SD-JWT VC). Available: <https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/>                                                                                                                                               |
 | [Topic 3]                              | ARF Annex 2 - Topic 3 - Attestation revocation and revocation checking Available: <https://eudi.dev/latest/annexes/annex-2/annex-2.02-high-level-requirements-by-topic/>                                                                                                 |
 | [Topic 12]                             | ARF Annex 2 - Topic 12 - Attestation Rulebooks, Available: <https://eudi.dev/latest/annexes/annex-2/annex-2.02-high-level-requirements-by-topic/>                                                                                                                        |
 | [W3C VCDM v2.0]                        | Sporny, M. *et al,* Verifiable Credentials Data Model v2.0, W3C Recommendation.                                                                                                                                                                                          |

--- a/rulebooks/rb-pid/README.md
+++ b/rulebooks/rb-pid/README.md
@@ -9,17 +9,21 @@ subtitle: "ARF Annex 3.01 - PID Rulebook"
 |---------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |
 | 0.1.3   | 27 Oct 2025 | Transferred main structure and content from [EUDI repository](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/rulebooks/pid/pid-rulebook.md) and modified template to closer align to [EUDI template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md). First specific draft for WE BUILD |
-|0.9.0| 2025-12-12  | Feedback of WeBuild WP 4 Task 2 implemented                                                                                                                                                                                                                                                                                                                                                                                       |
+| 0.9.0   | 2025-12-12  | Feedback of WeBuild WP 4 Task 2 implemented                                                                                                                                                                                                                                                                                                                                                                                       |
+| 0.9.9   | 2026-05-21  | Alignemnt to the ARF version 2.8.0 defined [PID version 1.5  ](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/rulebooks/pid/pid-rulebook.md)                                                                                                                                                                                                                                      |
+
 <!-- Usage help: (Name LastName, Affiliation) -->
 *  Authors
     * Jonas Toennis , [Brønnøysund Registry Center](https://www.brreg.no)
 
 * Previous authors
-  * David Bakker, Unknown Affiliation
-* 
+  * David Bakker, On behalf of the ARF working group 
+
+
+
 ### Feedback and contact
 Main feedback channel: [GitHub issues](https://github.com/webuild-consortium/eudi-wallet-rulebooks-and-schemas/issues)
-Alternative: Contact workpackage 4 in WE BUILD, or/and the author of the document. 
+Alternative: Contact workpackage 4 in WE BUILD.
 
 ## 1 Introduction
 
@@ -37,34 +41,27 @@ not included in the CIR.
 This document also specifies how a PID and all attributes in it are encoded if
 the PID complies with [ISO/IEC 18013-5] and if it complies with [SD-JWT VC].
 
-European Business Wallet – Owner Identification Data (formerly known as Legal Person Identification Data, LPID, or Person identification data for the legal person) is out of the scope of this document and is specified in the [European Business Wallet - Owner Identification Data Rulebook](../rb-ebw-oid/README.md).
+This PID Rulebook should be read in conjunction with the high-level requirements for PIDs in [Topic 3](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md#a232-topic-3---pid-rulebook) in Annex 2 of the Architecture Reference Framework. In particular, the values to be used for the namespace and document type for [ISO/IEC 18013-5]-compliant PIDs and for the vct claim in [SD-JWT VC]-compliant PIDs are defined in Topic 3.
 
-This PID Rulebook complies with all applicable requirements in Topic 12
-(Attestation Rulebooks) in Annex 2 of the Architecture Reference Framework.
+Person identification data for the legal person is out of scope of this document.
 
 ### 1.2 Document structure
 
 This PID Rulebook is structured as follows:
 
-- [Chapter 2](#2-attestation-attributes-and-metadata) describes the PID attributes and
-metadata on a generic level, regardless of the encoding used for the PID. Most
-of the content of this chapter is a direct copy of the Annex of Commission
-Implementing Regulation 2024/2977 on PID and EAA. However, a few additional
-attributes are specified in this chapter.
+- [Chapter 2](#2-pid-attributes-and-metadata) describes the PID attributes and
+  metadata on a generic level, regardless of the encoding used for the PID. Most
+  of the content of this chapter is a direct copy of the Annex of Commission
+  Implementing Regulation 2024/2977 on PID and EAA. However, a few additional
+  attributes are specified in this chapter.
 - [Chapter 3](#3-attestation-encoding) specifies how the PID
-attributes and metadata are encoded in the required formats
-- [Section 3.2](#32-sd-jwt-vc-based-encoding-of-pid) specifies how the PID
-attributes and metadata are encoded in case the PID complies with [SD-JWT VC].
-- **TODO: Add Chapter for W3C Json-ld** 
-- [Chapter 5](#4-attestation-usage) describes attestation usage guidelines, user
-and RP behaviours, and applicability scenarios. TODO: WE BUILD addition on the EUDI rulebook document based on the EUDI rulebook template.
-- [Chapter 6](#5-trust-anchors) describes trust anchor distribution and lookup
-mechanisms. TODO: WE BUILD addition on the EUDI rulebook document based on the EUDI rulebook template.
-- [Chapter 7](#6-revocation) describes revocation strategy and mechanisms.
-TODO: WE BUILD addition on the EUDI rulebook document based on the EUDI rulebook template.
-- [Chapter 8](#7-compliance) describes compliance criteria and conformance
-statements. TODO: WE BUILD addition on the EUDI rulebook document based on the EUDI rulebook template.
-- [Chapter 9](#8-references) lists references.
+  attributes and metadata are encoded in case the PID complies with [ISO/IEC
+  18013-5] or [SD-JWT VC]
+- [Chapter 4](#4-pid-usage) specifies how PIDs are issued and used.
+- [Chapter 5](#5-trust-anchors) discusses mechanisms for the provision of trust anchors that shall be used for the verification of PIDs.
+- [Chapter 6](#6-revocation) discusses how PIDs can be revoked, and how Relying Parties can perform revocation checking.
+- [Chapter 7](#7-compliance) states how this PID Rulebook complies with the general EUDI framework, the ARF, and relevant Regulations.
+- [Chapter 8](#8-references) lists references to relevant documents.
 
 ### 1.3 Keywords
 
@@ -84,20 +81,20 @@ statements of fact.
 
 This document uses the terminology specified in [Annex 1](https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-1/annex-1-definitions/) of the ARF.
 
-In addition, the following terms are used in this document:
+### 1.5 Deviations from the ARF 2.8.0 defined PID version 1.5 for webuild
+1. The attribute and metadata tables of chapter two have been extended with links to the semantic vocabulary of WE BUILD. 
+2. The structure of this rulebook follows the EUDI template version 1.1. The ARF PID rulebook is diverging from this version. 
+3. WE BUILD species an explicit tokenlist based status mapping for SD-JWT in line with [Architectur Decision Record for We Build on the topic ](https://github.com/webuild-consortium/wp4-architecture/blob/main/adr/attestation-revocation-mechanism.md)
+4. [Chapter 4](#4-pid-usage), [Chapter 5](#5-trust-anchors) and [Chapter 6](#6-revocation) have been expanded compared out over the ARF 2.8.0 PID version 1.5
 
-| Term | Definition in WE BUILD Context                                                                                                                                                                                                   |
-|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CDDL | CDDL stands for Concise Data Definition Language. It’s a formal notation used to describe the structure and constraints of data, especially in contexts where data is encoded using CBOR (Concise Binary Object Representation) |
-
-## 2 Attestation attributes and metadata
+## 2 PID attributes and metadata
 
 ### 2.1 Introduction
 
 Sections [2.2](#22-mandatory-attributes-specified-in-cir-20242977), [2.3](#23-optional-attributes-specified-in-cir-20242977), [2.4](#24-condition-attributes), [2.5](#25-mandatory-metadata-specified-in-cir-20242977) and [2.6](#26-optional-metadata-specified-in-cir-20242977) of this chapter list the mandatory and optional
 PID attributes and PID metadata defined in CIR 2024/2977. [Section 2.7](#27-additional-optional-attributes-specified-in-this-rulebook) lists the optional PID attributes additionally defined in this PID Rulebook.
 
-Note that, when requesting PID attributes from a Wallet Unit, a Relying Party is not required to request all mandatory attributes. Also, a User is allowed to refuse to present a mandatory attribute if it is requested by a Relying Party.
+Note that, when requesting PID attributes from a Wallet Unit, a Relying Party is not required to request all mandatory attributes. Also, a User is allowed to refuse to present a mandatory attribute, if it is requested by a Relying Party.
 
 The data identifiers and definitions given in Sections 2.2, 2.3, 2.4, and 2.5
 are identical to those in CIR 2024/2977, except where explicitly indicated that
@@ -107,122 +104,132 @@ All data identifiers and definitions in this chapter are independent of any
 encoding used. Consequently,
 
 - the data identifiers in these tables are not necessarily the same as the
-attribute identifiers used for PIDs complying with [ISO/IEC 18013-5]. [Chapter 3](#31-isoiec-18013-5-compliant-encoding) specifies the attribute
+attribute identifiers used for PIDs complying with [ISO/IEC 18013-5]. [Chapter 3.1](#31-isoiec-18013-5-compliant-encoding) specifies the attribute
 identifiers to be used for PIDs in [ISO/IEC 18013-5] format
 - the data identifiers in these tables are not necessarily the same as the claim
-names used for PIDs complying with [SD-JWT VC]. [Section 3.2](#32-sd-jwt-vc-based-encoding-of-pid) specifies the claim names to be
-used for such PIDs.
+names used for PIDs complying with [SD-JWT VC]. [Section 3.2](#32-sd-jwt-vc-based-encoding-of-pid) specifies the claim names to be used for such PIDs.
 
 ### 2.2 Mandatory attributes specified in CIR 2024/2977
 
-| **Data Identifier**  | **Semantic Reference** | **Definition**                                                                                                                                                                                                                         |
-|----------------------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| family_name          | [familyName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#familyName) | Current last name(s) or surname(s) of the user to whom the person identification data relates.                                                                                                                                         |
-| given_name           | [givenName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#givenName) | Current first name(s), including middle name(s) where applicable, of the user to whom the person identification data relates.                                                                                                          |
-| birth_date           | [dateOfBirth](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#dateOfBirth) | Day, month, and year on which the user to whom the person identification data relates was born.                                                                                                                                        |
-| birth_place          | [placeOfBirth](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#placeOfBirth) | The country as an alpha-2 country code as specified in ISO 3166-1, or the state, province, district, or local area or the municipality, city, town, or village where the user to whom the person identification data relates was born. |
-| nationality          | [citizenship](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#citizenship) | One or more alpha-2 country codes as specified in ISO 3166-1, representing the nationality of the user to whom the person identification data relates.                                                                                 |
+| Data Identifier | Semantic Reference                                                                   | Definition                                                                                                                                                                                                                             | Example value |
+|-----------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| family_name     | [familyName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#familyName)     | Current last name(s) or surname(s) of the user to whom the person identification data relates.                                                                                                                                         | 't Hart       |
+| given_name      | [givenName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#givenName)       | Current first name(s), including middle name(s) where applicable, of the user to whom the person identification data relates.                                                                                                          | Jan Wijnand   |
+| birth_date      | [dateOfBirth](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#dateOfBirth)   | Day, month, and year on which the user to whom the person identification data relates was born.                                                                                                                                        | 12/02/1978    |
+| birth_place     | [placeOfBirth](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#placeOfBirth) | The country as an alpha-2 country code as specified in ISO 3166-1, or the state, province, district, or local area or the municipality, city, town, or village where the user to whom the person identification data relates was born. | Amsterdam     |
+| nationality     | [citizenship](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#citizenship)   | One or more alpha-2 country codes as specified in ISO 3166-1, representing the nationality of the user to whom the person identification data relates.                                                                                 | NL            |
+
 
 ### 2.3 Optional attributes specified in CIR 2024/2977
-
-| **Data Identifier**  | **Semantic Reference** | **Definition**                                                                                                                                                                                                                         |
-|----------------------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| resident_address               | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[fullAddress](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#fullAddress) | The full address of the place where the user to whom the person identification data relates currently resides or can be contacted (street name, house number, city etc.).                                                                                                                                                                                                                                                                                                    |
-| resident_country               | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[adminUnitL1](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#adminUnitL1) | The country where the user to whom the person identification data relates currently resides, as an alpha-2 country code as specified in ISO 3166-1.                                                                                                                                                                                                                                                                                                                          |
-| resident_state                 | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[adminUnitL2](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#adminUnitL2) | The state, province, district, or local area where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                                |
-| resident_city                  | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[postName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#postName) | The municipality, city, town, or village where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                                    |
-| resident_postal_code           | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[postCode](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#postCode) | The postal code of the place where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                                                |
-| resident_street                | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[thoroughfare](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#thoroughfare) | The name of the street, which may include the house number, where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                 |
-| personal_administrative_number | [personalAdministrativeNumber](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#personalAdministrativeNumber) | A value assigned to the natural person that is unique among all personal administrative numbers issued by the provider of person identification data. Where Member States opt to include this attribute, they shall describe in their electronic identification schemes under which the person identification data is issued, the policy that they apply to the values of this attribute, including, where applicable, specific conditions for the processing of this value. |
-| portrait                       | [portrait](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#portrait) | Facial image of the wallet user compliant with ISO 19794-5 or ISO 39794 specifications.                                                                                                                                                                                                                                                                                                                                                                                      |
-| family_name_birth              | [birthName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#birthName) | Last name(s) or surname(s) of the User to whom the person identification data relates at the time of birth.                                                                                                                                                                                                                                                                                                                                                                  |
-| given_name_birth               | [birthName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#birthName) | First name(s), including middle name(s), of the User to whom the person identification data relates at the time of birth.                                                                                                                                                                                                                                                                                                                                                    |
-| sex                            | [gender](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#gender) | Values shall be one of the following: 0 = not known; 1 = male; 2 = female; 3 = other; 4 = inter; 5 = diverse; 6 = open; 9 = not applicable. For values 0, 1, 2 and 9, ISO/IEC 5218 applies.                                                                                                                                                                                                                                                                                  |
-| email_address                  | [contactPoint](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#contactPoint).[hasEmail](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#email) | Electronic mail address of the user to whom the person identification data relates, in conformance with [RFC 5322].                                                                                                                                                                                                                                                                                                                                                          |
-| mobile_phone_number            | [contactPoint](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#contactPoint).[hasTelephone](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#telephone)| Mobile telephone number of the User to whom the person identification data relates, starting with the '+' symbol as the international code prefix and the country code, followed by numbers only.                                                                                                                                                                                                                                                                            |
+| \*\*Data Identifier\*\*        | \*\*Semantic Reference\*\*                                                                                                                                             | Definition                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Example value                                               |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| resident_address               | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[fullAddress](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#fullAddress)        | The full address of the place where the user to whom the person identification data relates currently resides or can be contacted (street name, house number, city etc.).                                                                                                                                                                                                                                                                                                    | Rietveld 1, 2312 JD, Leiden                                 |
+| resident_country               | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[adminUnitL1](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#adminUnitL1)        | The country where the user to whom the person identification data relates currently resides, as an alpha-2 country code as specified in ISO 3166-1.                                                                                                                                                                                                                                                                                                                          | NL                                                          |
+| resident_state                 | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[adminUnitL2](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#adminUnitL2)        | The state, province, district, or local area where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                                | Zuid-Holland                                                |
+| resident_city                  | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[postName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#postName)              | The municipality, city, town, or village where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                                    | Leiden                                                      |
+| resident_postal_code           | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[postCode](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#postCode)              | The postal code of the place where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                                                | 2312 JD                                                     |
+| resident_street                | [domicile](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#domicile).[thoroughfare](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#thoroughfare)      | The name of the street where the user to whom the person identification data relates currently resides.                                                                                                                                                                                                                                                                                                                                                                      | Rietveld                                                    |
+| resident_house_number          |                                                                                                                                                                        | The house number where the user to whom the person identification data relates currently resides, including any affix or suffix.                                                                                                                                                                                                                                                                                                                                             | 1                                                           |
+| personal_administrative_number | [personalAdministrativeNumber](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#personalAdministrativeNumber)                                                   | A value assigned to the natural person that is unique among all personal administrative numbers issued by the provider of person identification data. Where Member States opt to include this attribute, they shall describe in their electronic identification schemes under which the person identification data is issued, the policy that they apply to the values of this attribute, including, where applicable, specific conditions for the processing of this value. | 123456782                                                   |
+| portrait                       | [portrait](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#portrait)                                                                                           | [Facial image of the wallet user compliant with ISO 19794-5 or ISO 39794 specifications. Further clarification added in this PID Rulebook: The detailed format of the portrait is specified in requirement PID_03 in Annex 2, Topic 3.](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md#a232-topic-3---pid-rulebook)                               | \-                                                          |
+| family_name_birth              | [birthName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#birthName)                                                                                         | Last name(s) or surname(s) of the User to whom the person identification data relates at the time of birth.                                                                                                                                                                                                                                                                                                                                                                  | Poepjes                                                     |
+| given_name_birth               | [birthName](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#birthName)                                                                                         | First name(s), including middle name(s), of the User to whom the person identification data relates at the time of birth.                                                                                                                                                                                                                                                                                                                                                    | Björn                                                       |
+| sex                            | [gender](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#gender)                                                                                               | Values shall be one of the following: 0 = not known; 1 = male; 2 = female; 3 = other; 4 = inter; 5 = diverse; 6 = open; 9 = not applicable. For values 0, 1, 2 and 9, ISO/IEC 5218 applies.                                                                                                                                                                                                                                                                                  | 1                                                           |
+| email_address                  | [contactPoint](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#contactPoint).[hasEmail](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#email)         | Electronic mail address of the user to whom the person identification data relates, in conformance with [RFC 5322].                                                                                                                                                                                                                                                                                                                                                          | [wijnandthart@example.com](mailto:wijnandthart@example.com) |
+| mobile_phone_number            | [contactPoint](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#contactPoint).[hasTelephone](https://ebw-vocabulary.spherity.dev/ebw/v0.1/vocabulary#telephone) | Mobile telephone number of the User to whom the person identification data relates, starting with the '+' symbol as the international code prefix and the country code, followed by numbers only.                                                                                                                                                                                                                                                                            | 31123456789                                                 |                                                                                                                                                                                                                                                         |
 
 ### 2.4 Condition Attributes
 The PID defined in this rulebook does not contain any condition attributes.
 
 ### 2.5 Mandatory metadata specified in CIR 2024/2977
 
-| **Data Identifier** | **Definition**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| attestation_legal_category | An indication, in a form suitable for automated processing, that the attestation has been issued as a QEAA, PUB-EAA or EAA.  This attribute is defined in accordance with ARB_25 in [Topic 12] of Annex 2 of the ARF, which requires that each attestation carry an indication of its legal category.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| expiry_date         | Date (and if possible time) when the person identification data will expire. **Further clarification added in this PID Rulebook:** This attribute, as well as the optional issuance_date attribute specified in [Section 2.5](#25-mandatory-metadata-specified-in-cir-20242977), pertains to the administrative validity period of the PID. It is up to the PID Provider to decide whether a PID has an administrative validity period. However, if present, it in general is different from the technical validity period of a PID. The technical validity period is a mandatory element of all PIDs (and also attestations) in the EUDI Wallet ecosystem. It typically is short, a few days or weeks at most, if not shorter, to mitigate challenges regarding tracking of Users by malicious Relying Parties based on the repeated presentation of the same PID. On the other hand, the administrative validity period is typically at least a few years long. During the administrative validity period of a PID, the PID Provider will therefore provide multiple successive PIDs to a User, typically without any actions being expected from the User. However, when the administrative validity period of a PID ends, typically the User has to apply for an entirely new PID. |
-| issuing_authority   | Name of the administrative authority that issued the person identification data, or the ISO 3166 alpha-2 country code of the respective Member State if there is no separate authority entitled to issue person identification data. TODO: Is name okay here, or do we want something like the EUID here if available?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| issuing_country     | Alpha-2 country code, as specified in ISO 3166-1, of the country or territory of the provider of the person identification data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Data Identifier** | **Definition**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | **Example value**                    |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| expiry_date         | Date (and if possible time) when the person identification data will expire. **Further clarification added in this PID Rulebook:** This attribute, as well as the optional issuance_date attribute specified in [Section 2.7](#27-additional-optional-attributes-specified-in-this-rulebook), pertains to the administrative validity period of the PID. It is up to the PID Provider to decide whether a PID has an administrative validity period. However, if present, it in general is different from the technical validity period of a PID. The technical validity period is a mandatory element of all PIDs (and also attestations) in the EUDI Wallet ecosystem. It typically is short, a few days or weeks at most, if not shorter, to mitigate challenges regarding tracking of Users by malicious Relying Parties based on the repeated presentation of the same PID. On the other hand, the administrative validity period is typically at least a few years long. During the administrative validity period of a PID, the PID Provider will therefore provide multiple successive PIDs to a User, typically without any actions being expected from the User. However, when the administrative validity period of a PID ends, typically the User has to apply for an entirely new PID. | 19-12-2025                           |
+| issuing_authority   | Name of the administrative authority that issued the person identification data, or the ISO 3166 alpha-2 country code of the respective Member State if there is no separate authority entitled to issue person identification data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Rijksdienst voor Identiteitsgegevens |
+| issuing_country     | Alpha-2 country code, as specified in ISO 3166-1, of the country or territory of the provider of the person identification data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | NL                                   |
+
 
 ### 2.6 Optional metadata specified in CIR 2024/2977
 
-| **Data Identifier**  | **Definition**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| document_number      | A number for the person identification data, assigned by the provider of person identification data. **Further clarification added in this rulebook** This number is of administrative purpose for the issuer, and not relate to the status lists numbering.                                                                                                                                                                                                                                                                         |
-| issuing_jurisdiction | Country subdivision code of the jurisdiction that issued the person identification data, as specified in ISO 3166-2:2020, Clause 8. The first part of the code shall be the same as the value for the issuing country.                                                                                                                                                                                                                                                                                                               |
-| location_status      | The location of validity status information on the person identification data where the providers of person identification data revoke person identification data.                                                                                                                                                                                                                                                                                                                                                                   |
-| trust_anchor        | This attribute indicates at least the URL at which a machine-readable version of the trust anchor to be used for verifying the PID can be found or looked up. *Note: This attribute corresponds to the location meant in Annex V point h) or Annex VII point h) of the [European Digital Identity Regulation], which is mandatory for QEAAs. This PID Rulebook adds this as an optional attribute for PIDs as well, so PID Providers are able to ensure that PIDs can be validated by Relying Parties in the same manner as QEAAs.*  |
+| **Data Identifier**  | **Definition**                                                                                                                                                                                                         | **Example value**                      |
+|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| document_number      | A number for the person identification data, assigned by the provider of person identification data.                                                                                                                   | A01234567                              |
+| issuing_jurisdiction | Country subdivision code of the jurisdiction that issued the person identification data, as specified in ISO 3166-2:2020, Clause 8. The first part of the code shall be the same as the value for the issuing country. | NL                                     |
+| location_status      | The location of validity status information on the person identification data where the providers of person identification data revoke person identification data.                                                     | <https://example.com/statuslists/pid/> |
 
 
 ### 2.7 Additional optional attributes specified in this Rulebook
 
-| **Data Identifier** | **Definition**                                                                                                                                                                                                                                                                |
-|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| issuance_date       | Date (and if possible time) when the person identification data was issued and/or the administrative validity period of the person identification data began. See also the clarification for expiry_date in [Section 2.5](#25-mandatory-metadata-specified-in-cir-20242977).  |
+| **Data Identifier**        | **Definition**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | **Example value**                       |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| issuance_date              | Date (and if possible time) when the person identification data was issued and/or the administrative validity period of the person identification data began. See also the clarification for expiry_date in [Section 2.5](#25-mandatory-metadata-specified-in-cir-20242977).                                                                                                                                                                                                                                                        | 19-12-2025                              |
+| trust_anchor               | This attribute indicates at least the URL at which a machine-readable version of the trust anchor to be used for verifying the PID can be found or looked up. *Note: This attribute corresponds to the location meant in Annex V point h) or Annex VII point h) of the [European Digital Identity Regulation], which is mandatory for QEAAs. This PID Rulebook adds this as an optional attribute for PIDs as well, so PID Providers are able to ensure that PIDs can be validated by Relying Parties in the same manner as QEAAs.* | <https://example.com/trustanchors/pid/> |
+| attestation_legal_category | This attribute indicates that a PID has indeed been issued as a PID. *Note: According to Annex V point a) and Annex VII point a) of the [European Digital Identity Regulation] an indication, at least in a form suitable for automated processing, that the attestation has been issued as a QEAA or Pub-EAA SHALL be defined. This PID Rulebook adds this as an optional attribute for PIDs as well, so PID Providers are able to ensure that PIDs can be validated by Relying Parties in the same manner as QEAAs.*              | PID                                     |
 
 # 3 Attestation encoding
 
 ## 3.1 ISO/IEC 18013-5-compliant encoding
-#### 3.1.1 Overview
+#### 3.1.1 Document type and namespace
+
+As specified in [Topic 3](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md#a232-topic-3---pid-rulebook) in Annex 2 of the ARF, "eu.europa.ec.eudi.pid.1" will be used as the attestation type for ISO/IEC 18013-5-compliant PIDs.
+
+Similarly, "eu.europa.ec.eudi.pid.1" will be used for the namespace of the attributes specified below.
+
+#### 3.1.2 Attributes overview
 
 The ISO/IEC 18013-5-compliant encoding of PID attributes and metadata is
 specified in the table below. The table contains the following information for
 all attributes:
 
 - The first column lists the data identifier specified in
-[Chapter 2](#2-attestation-attributes-and-metadata) above.
+  [Chapter 2](#2-pid-attributes-and-metadata) above.
 - The second column lists the corresponding attribute identifier to be used in
-presentation requests and responses according to [ISO/IEC 18013-5].
+  presentation requests and responses according to [ISO/IEC 18013-5].
 - The third column indicates the encoding of each attribute. This column uses
-CDDL representation types defined in [RFC 8610]. The following notes and
-requirements apply:
-    - ``tstr``, ``uint``, ``bstr``, ``bool`` and ``tdate`` are CDDL representation types defined in [RFC 8610].
-    - Regarding type ``tstr``: this document confirms that, as specified in RFC
+  CDDL representation types defined in [RFC 8610]. The following notes and
+  requirements apply:
+  - ``tstr``, ``uint``, ``bstr``, ``bool`` and ``tdate`` are CDDL representation types defined in [RFC 8610].
+  - Regarding type ``tstr``: this document confirms that, as specified in RFC
     8949, a ``tstr`` SHALL be encoded in UTF-8 and SHALL support the full Unicode
     range.
-    - All attributes having encoding type ``tstr`` SHALL have a maximum length of
+  - All attributes having encoding type ``tstr`` SHALL have a maximum length of
     150 characters.
-    - This document specifies ``full-date`` as ``full-date = #6.1004(tstr)``, where tag
+  - This document specifies ``full-date`` as ``full-date = #6.1004(tstr)``, where tag
     1004 is specified in [RFC 8943].
-    - In accordance with [RFC 8949], section 3.4.1, a ``tdate`` attribute SHALL
+  - In accordance with [RFC 8949], section 3.4.1, a ``tdate`` attribute SHALL
     contain a date-time string as specified in [RFC 3339]. In accordance with
     [RFC 8943], a ``full-date`` attribute SHALL contain a full-date string as
     specified in [RFC 3339].
-    - The following requirements apply to the representation of dates in
+  - The following requirements apply to the representation of dates in
     attributes, unless otherwise indicated:
-        - Fractions of seconds SHALL NOT be used;
-        - A local offset from UTC SHALL NOT be used; the time-offset defined in
-        [RFC 3339] SHALL be to "Z".
-    - RFC 8949, section 4.2, describes four rules for canonical CBOR. Three of
+    - Fractions of seconds SHALL NOT be used;
+    - A local offset from UTC SHALL NOT be used; the time-offset defined in
+      [RFC 3339] SHALL be to "Z".
+  - RFC 8949, section 4.2, describes four rules for canonical CBOR. Three of
     those rules SHALL be implemented for all CBOR structures in PIDs, as
     follows:
-        - integers (major types 0 and 1) SHALL be as small as possible;
-        - the expression of the length in a ``bstr``, ``tstr``, array or map SHALL be as
-        short as possible;
-        - indefinite-length items SHALL be made into definite-length items.
+    - integers (major types 0 and 1) SHALL be as small as possible;
+    - the expression of the length in a ``bstr``, ``tstr``, array or map SHALL be as
+      short as possible;
+    - indefinite-length items SHALL be made into definite-length items.
+
+Note that the presence of each attribute (mandatory or optional) is already specified in [Chapter 2](#2-pid-attributes-and-metadata) above.
 
 | **Data Identifier**            | **Attribute identifier**       | **Encoding format**                                                                                      |
 |--------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|
 | family_name                    | family_name                    | ``tstr``                                                                                                 |
 | given_name                     | given_name                     | ``tstr``                                                                                                 |
-| birth_date                     | birth_date                     | ``full-date``, see [Section 3.1.4](#314-attribute-birth_date).                                           |
-| birth_place                    | place_of_birth                 | ``place_of_birth``, see [Section 3.1.5](#315-attribute-place_of_birth).                                  |
-| nationality                    | nationality                    | ``nationalities``, see [Section 3.1.2](#312-attribute-nationality).                                      |
+| birth_date                     | birth_date                     | ``full-date``, see [Section 3.1.5](#315-attribute-birth_date).                                           |
+| birth_place                    | place_of_birth                 | ``place_of_birth``, see [Section 3.1.6](#316-attribute-place_of_birth).                                  |
+| nationality                    | nationality                    | ``nationalities``, see [Section 3.1.3](#313-attribute-nationality).                                      |
 | resident_address               | resident_address               | ``tstr``                                                                                                 |
 | resident_country               | resident_country               | ``tstr``                                                                                                 |
 | resident_state                 | resident_state                 | ``tstr``                                                                                                 |
 | resident_city                  | resident_city                  | ``tstr``                                                                                                 |
 | resident_postal_code           | resident_postal_code           | ``tstr``                                                                                                 |
 | resident_street                | resident_street                | ``tstr``                                                                                                 |
+| resident_house_number          | resident_house_number          | ``tstr``                                                                                                 |
 | personal_administrative_number | personal_administrative_number | ``tstr``                                                                                                 |
 | portrait                       | portrait                       | ``bstr``; see additional information in [Section 2.3](#23-optional-attributes-specified-in-cir-20242977) |
 | family_name_birth              | family_name_birth              | ``tstr``                                                                                                 |
@@ -230,17 +237,17 @@ requirements apply:
 | sex                            | sex                            | ``uint``; see additional information in [Section 2.3](#23-optional-attributes-specified-in-cir-20242977) |
 | email_address                  | email_address                  | ``tstr``                                                                                                 |
 | mobile_phone_number            | mobile_phone_number            | ``tstr``                                                                                                 |
-| attestation_legal_category     | attestation_legal_category     | ``tstr``                                                                                                 |
 | expiry_date                    | expiry_date                    | ``tdate`` or ``full-date``                                                                               |
 | issuing_authority              | issuing_authority              | ``tstr``                                                                                                 |
 | issuing_country                | issuing_country                | ``tstr``                                                                                                 |
 | document_number                | document_number                | ``tstr``                                                                                                 |
 | issuing_jurisdiction           | issuing_jurisdiction           | ``tstr``                                                                                                 |
-| location_status                | -                              | See [Section 3.1.3](#313-attribute-location_status).                                                     |
+| location_status                | -                              | See [Section 3.1.4](#314-attribute-location_status).                                                     |
 | issuance_date                  | issuance_date                  | ``tdate`` or ``full-date``                                                                               |
 | trust_anchor                   | trust_anchor                   | ``tstr``                                                                                                 |
+| attestation_legal_category     | attestation_legal_category     | ``tstr``                                                                                                 |
 
-#### 3.1.2 Attribute nationality
+#### 3.1.3 Attribute nationality
 
 The attribute nationality is encoded as a type ``nationalities``, i.e., an array of Alpha-2 country codes as specified in ISO 3166-1. Using CDDL notation as specified in RFC 8610, the
 encoding of this attribute is:
@@ -253,30 +260,33 @@ CountryCode = tstr ; Alpha-2 country code specified in ISO 3166-1
 
 Note: If the User to whom the person identification data relates has multiple
 nationalities (and the PID Provider is willing to attest to these multiple
-nationalities), the PID Provider can include all the nationalities in the
-nationality array. A potential drawback of this solution is that the User
+nationalities), the PID Provider can include all of the nationalities in the
+nationalities array. A potential drawback of this solution is that the User
 cannot selectively disclose only one of these nationalities, since for ISO/IEC
 18013-5-compliant attestations, always the entire array will be presented if the
 User approves the presentation of the nationality attribute. A potential
 solution to this challenge is for the PID Provider to include only one
 nationality in the nationality attribute, and for the remaining nationalities
 use one or more domestic data attributes specified according to requirement
-PID_06 in [Annex 2, Topic 3](https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/).
+PID_06 in [Annex 2, Topic 3](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md#a232-topic-3---pid-rulebook).
 
-#### 3.1.3 Attribute location_status
+#### 3.1.4 Attribute location_status
 
 For ISO/IEC 18013-5-compliant PIDs, the attribute location_status is
 absent, since the PID issuer will add revocation information, if needed, to the MSO as specified in [ISO/IEC 18013-5].
 
-#### 3.1.4 Attribute birth_date
+#### 3.1.5 Attribute birth_date
 
-For PIDs compliant with ISO/IEC 18013-5, dates are encoded as specified in RFC 8943. This encoding does not contain provisions for encoding partial dates. This may cause challenges in case the birthdate of a User is not (fully) known. To deal with such cases, a PID Provider could adopt a policy to choose appropriate values for the unknown date elements. However, mandating such a policy is out of the scope of this document.
+For PIDs compliant with ISO/IEC 18013-5, dates are encoded as specified in RFC 8949 (which references RFC 3339). This encoding does not contain provisions for encoding partial dates. This
+may cause challenges in case the birth date of a User is not (fully) known. To
+deal with such cases, a PID Provider could adopt a policy to choose appropriate (and RFC 3339-compliant) values for the unknown date elements. However, mandating such a policy is out of
+scope of this document.
 
-#### 3.1.5 Attribute place_of_birth
+#### 3.1.6 Attribute place_of_birth
 
 The attribute place_of_birth is encoded as a type ``place_of_birth``.
 Using CDDL notation as specified in RFC 8610, the encoding of this attribute is:
-  
+
 ``` cddl
 place_of_birth =
 {
@@ -285,11 +295,9 @@ place_of_birth =
   ? "locality": tstr ; the name of a municipality, city, town, or village
 }
 ```
+
 place_of_birth SHALL contain at least one of the following key-value pairs: ``"country"``, ``"region"``, or ``"locality"``.
 
-### 3.1.6 Example mdoc
-
-TODO: Provide an illustrative mdoc (ISO/IEC 18013-5) example showing a PID with representative attributes and their encoding.
 
 ## 3.2 SD-JWT VC-based encoding of PID
 
@@ -334,21 +342,23 @@ The following Private Names specific to the attestation type defined in this doc
 
 | **Data Identifier**            | **Attribute identifier**       | **Encoding format** | **Notes**                                                                                                                                                                    |
 |--------------------------------|--------------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| attestation_legal_category     | attestation_legal_category     | string              | SHALL be one of QEAA, PUB-EAA or EAA                                                                                                                                                               |
+| attestation_legal_category     | attestation_legal_category     | string              | SHALL be `PID`                                                                                                                                                                |
 | expiry_date                    | date_of_expiry                 | string              | ISO 8601-1 [ISO8601‑1] YYYY-MM-DD format, as defined in Section 5.4.4.2 of [EKYC Schema]                                                                                     |
 | issuance_date                  | date_of_issuance               | string              | ISO 8601-1 [ISO8601‑1] YYYY-MM-DD format, as defined in Section 5.4.4.2 of [EKYC Schema]                                                                                     |
 | personal_administrative_number | personal_administrative_number | string              |                                                                                                                                                                              |
+| resident_house_number          | address.house_number           | string              | This document extends the specification of ``address`` in [OIDC] with an additional member ``address.house_number``                                                          |
 | sex                            | sex                            | number              | numeric encoding as described in [Section 2.3](#23-optional-attributes-specified-in-cir-20242977); gender from [OIDC] uses a different value range and is therefore not used |
 | issuing_authority              | issuing_authority              | string              |                                                                                                                                                                              |
 | issuing_country                | issuing_country                | string              |                                                                                                                                                                              |
 | document_number                | document_number                | string              |                                                                                                                                                                              |
 | issuing_jurisdiction           | issuing_jurisdiction           | string              |                                                                                                                                                                              |
-| status                         | status                         | JSON object         | See [Section 3.2.2](#322-attribute-status)                                                                                                                                   |
+| location_status                         | status                         | JSON object         | See [Section 3.2.2](#322-attribute-status)                                                                                                                                   |
 | trust_anchor                   | trust_anchor                   | string              |                                                                                                                                                                              |
+
 
 ### 3.2.2 Attribute status
 
-For SD-JWT VC-compliant PIDs, the PID MUST include a `status` claim if the technical validity period is greater than 25 hours. This claim enables Relying Parties to determine if a credential has been revoked via a status list mechanism, as specified in [SD-JWT VC](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/12/).
+For SD-JWT VC-compliant PIDs, the PID MUST include a `status` claim if the technical validity period is greater than 25 hours. This claim enables Relying Parties to determine if a credential has been revoked via a status list mechanism, as specified in [SD-JWT VC](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/16/).
 
 The `status` claim SHALL be a JSON object with the following members:
 - `type` (string): SHALL be `"status-list"`.
@@ -377,22 +387,20 @@ optional or mandatory in the SD-JWT VC, and specifies their display
 methods. Additionally, a type can extend another type, enabling
 the creation of domestic types based on a common EU-wide type, while preserving
 the mandatory claims from the base type. Domestic
-types MAY, however, define additional claims and display information. Details
+types MAY however define additional claims and display information. Details
 are defined in [SD-JWT VC].
 
-This document defines the base type to be "urn:eudi:pid:1". As a convention, all
-PIDs must use types in the namespace "urn:eudi:pid:".
+Requirement PID_14 in ARF Annex 2 defines the base type to be "urn:eudi:pid:1". As a convention, all PIDs must use types in the namespace "urn:eudi:pid:".
 
 SD-JWT VC specifies Type Metadata as a machine-readable format for information
 regarding a type, including the information on claims such as what is contained
-in this document. Requirement PID_15 in [Annex 2, Topic 3](https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/) requires that the information on the
+in this document. Requirement PID_15 in [Annex 2, Topic 3](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md#a232-topic-3---pid-rulebook) requires that the information on the
 common EU-wide type as well as on any domestic types is published and
-accessible in a catalogue.
+accessible in a catalog.
 
-**Further clarification added in this rulebook for WE BUILD**: We encourage the use of the EUDI standard for WE BUILD Pilots, over national standards and extensions.
 
 ### 3.3 SD-JWT version 
-For WE BUILD we focus on following the sd-jwt standard draft version 12, [which can be found here](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/12/)
+For WE BUILD we focus on following the sd-jwt standard draft version 16, [which can be found here](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/16/)
 
 ### 3.4 Example
 
@@ -450,7 +458,7 @@ The example above shows a public key in JWK format.
 Note: Additional technical claims are not shown here, including
 references to the issuer and more.
 
-## 4 Attestation usage
+## 4 PID usage
 
 ### 4.1 Use-case context
 
@@ -545,23 +553,50 @@ Practical examples (illustrative):
 
 ## 6 Revocation
 
-TODO: WE BUILD WP4 - PID/EBW-OID group task 5
+PIDs MAY be either (a) short-lived and non-revocable, or (b) long-lived and revocable, in line with ARF Annex 2 Topic 7.
+
+Revocation strategy:
+- A PID Provider SHALL use one of the following approaches:
+  - Issue short-lived PIDs with a technical validity period of 24 hours or less; or
+  - Support revocation using an Attestation Status List (ASL) or Attestation Revocation List (ARL) mechanism.
+- If a PID is revocable, the PID Provider SHALL be the only party responsible for executing revocation of that PID, and SHALL NOT reverse revocation once executed.
+- The PID Provider MAY support temporary suspension before permanent revocation, with a maximum suspension period defined in the revocation policy.
+- The PID Provider SHALL maintain a revocation policy specifying under which conditions it revokes a PID (e.g. compromise, attribute changes, explicit User request, death of the subject), notification procedures for Users, and User rights including the right to request revocation at any time.
+
+Technical mechanisms:
+- For SD-JWT VC-based PIDs, revocation is expressed via the `status` claim (see Section 3.2.2) using the status-list mechanism.
+- For ISO/IEC 18013-5-compliant PIDs, revocation information is provided via the MSO as defined in ISO/IEC 18013-5; no `location_status` attribute is used (see Section 3.1.3).
+
+Relying Party (RP) checks:
+- A Relying Party Instance SHOULD verify revocation status when the PID is revocable, and SHALL perform a risk analysis if it decides not to.
+- Relying Parties SHOULD NOT fetch status information at presentation time. Instead, they SHOULD periodically retrieve and cache the relevant ASL/ARL and distribute it to their Relying Party Instances.
+- If reliable revocation information is unavailable or indeterminate, the RP SHALL decide whether to accept or refuse the PID based on its risk analysis. The RP SHALL log such incidents and MAY report recurring failures to the PID Provider.
+- Revocation status checking SHALL be designed to prevent correlation of User identity across Relying Parties (e.g., using batch status lists rather than per-credential status endpoints).
+
+Timing:
+- Where revocation is supported, the PID Provider SHOULD ensure that revocation is reflected in published status information within 24 hours of the revocation decision.
+- For emergency revocations (e.g., security compromise), the PID Provider SHOULD propagate revocation within a shorter timeframe where technically feasible.
 
 ## 7 Compliance
+This PID Rulebook complies with all applicable requirements in [Topic 12
+(Attestation Rulebooks)](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md#a239-topic-12---attestation-rulebooks) in Annex 2 of the Architecture Reference Framework. It also complies with the [template for Attestation Rulebooks](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md).
 
+The attributes specified in this Rulebook comply with [CIR 2024/2977](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202402977).
+
+Further requirements in this Rulebook comply with or reference the applicable requirements in the ARF and the relevant Implementing Acts.
 
 ## 8 References
 
-| **Item Reference**                     | **Standard name/details**                                                                                                                                                                                                                                                                          |
-|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [European Digital Identity Regulation] | [Regulation (EU) 2024/1183](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202401183) of the European Parliament and of the Council of 11 April 2024 amending Regulation (EU) No 910/2014 as regards establishing the European Digital Identity Framework                           |
-| [ISO/IEC 18013-5]                      | ISO/IEC 18013-5, Personal identification --- ISO-compliant driving licence - Part 5: Mobile driving licence (mDL) application, First edition, 2021-09                                                                                                                                              |
-| [OIDC]                                 | Sakimura, N. et al., "OpenID Connect Core 1.0", OpenID Foundation. Available: <https://openid.net/specs/openid-connect-core-1_0.html>                                                                                                                                                              | 
-| [EKYC]                                 | OpenID Connect for Identity Assurance Claims Registration <https://openid.net/specs/openid-connect-4-ida-claims-1_0-final.html#ICAO-Doc9303>                                                                                                                                                       |
-| [SD-JWT VC]                            | SD-JWT-based Verifiable Credentials (SD-JWT VC). Available: <https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/>, version draft-ietf-oauth-sd-jwt-vc-09                                                                                                                                  |
-| [Topic 3]                              | ARF Annex 2 - Topic 3 - Attestation revocation and revocation checking Available: <https://eudi.dev/latest/annexes/annex-2/annex-2.02-high-level-requirements-by-topic/> |
-| [Topic 12]                             | ARF Annex 2 - Topic 12 - Attestation Rulebooks, Available: <https://eudi.dev/latest/annexes/annex-2/annex-2.02-high-level-requirements-by-topic/>                                               |
-| [W3C VCDM v2.0]                        | Sporny, M. *et al,* Verifiable Credentials Data Model v2.0, W3C Recommendation.                                                                                                                                                                                                                    |
+| **Item Reference**                     | **Standard name/details**                                                                                                                                                                                                                                                |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [European Digital Identity Regulation] | [Regulation (EU) 2024/1183](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202401183) of the European Parliament and of the Council of 11 April 2024 amending Regulation (EU) No 910/2014 as regards establishing the European Digital Identity Framework |
+| [ISO/IEC 18013-5]                      | ISO/IEC 18013-5, Personal identification --- ISO-compliant driving licence - Part 5: Mobile driving licence (mDL) application, First edition, 2021-09                                                                                                                    |
+| [OIDC]                                 | Sakimura, N. et al., "OpenID Connect Core 1.0", OpenID Foundation. Available: <https://openid.net/specs/openid-connect-core-1_0.html>                                                                                                                                    | 
+| [EKYC]                                 | OpenID Connect for Identity Assurance Claims Registration <https://openid.net/specs/openid-connect-4-ida-claims-1_0-final.html#ICAO-Doc9303>                                                                                                                             |
+| [SD-JWT VC]                            | SD-JWT-based Verifiable Credentials (SD-JWT VC). Available: <https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/>, version draft-ietf-oauth-sd-jwt-vc-09                                                                                                        |
+| [Topic 3]                              | ARF Annex 2 - Topic 3 - Attestation revocation and revocation checking Available: <https://eudi.dev/latest/annexes/annex-2/annex-2.02-high-level-requirements-by-topic/>                                                                                                 |
+| [Topic 12]                             | ARF Annex 2 - Topic 12 - Attestation Rulebooks, Available: <https://eudi.dev/latest/annexes/annex-2/annex-2.02-high-level-requirements-by-topic/>                                                                                                                        |
+| [W3C VCDM v2.0]                        | Sporny, M. *et al,* Verifiable Credentials Data Model v2.0, W3C Recommendation.                                                                                                                                                                                          |
 
 For further references please see [ARF Chapter 10](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/architecture-and-reference-framework-main.md#10-references) of the ARF main document.
 


### PR DESCRIPTION
*  Locking and updating based on the ARF 2.8.0 PID rulebook version 1.5. No significant divergences. Mainly structure (WeBuild structure kept), some terminology, and formulations, as well as movement between under which chapters attributes are defined. 
* Added a list of divergences between the ARF PID rulebook and the WEBUILD rulebook (section 1.5 
* SDJWT-VC version moved from 12 -> 16. Version 16  was released in April. In general no major changes as far as I see except for some status codes on the metadata api calls. 