### PR TITLE
Versioning info, VCTM info for PID + EBWOID and EUCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository hosts the rulebooks and data schemas used across the WE BUILD La
 
 Project structure (high level):
 - `rulebooks/` — Human‑readable rulebooks and regulatory references.
+- `vctm/` — Verification Credential Trust Model (VCTM) documents for digestion into registry.siros.org
 - `data-schemas/` — Machine‑readable schemas (e.g., JSON Schema for SD‑JWT claims), with samples under `sample-data/`.
 - `sample-data/` — Additional example payloads that complement the schemas.
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,70 @@
+# Versioning
+
+This document describes how versioning is managed across the different artefact types in this repository.
+
+## Overview
+
+The repository contains three distinct types of artefacts, each with its own versioning mechanism:
+
+| Artefact type | Where the version lives | Versioning cadence |
+|---|---|---|
+| Rulebooks | Version table inside each rulebook's `README.md` | Per-document, independent |
+| JSON Schemas | `version` field inside each `.json` schema file | Per-schema, independent |
+| VCTM Credentials | File path (new file per version) | Major versions only |
+
+In addition, the repository itself is tagged at major milestone points to pin a snapshot of all artefacts to a WE BUILD deliverable.
+
+---
+
+## Rulebooks
+
+Each rulebook lives under `rulebooks/<rb-name>/` and carries its own version history in a Markdown table at the top of its `README.md`, for example:
+
+```markdown
+| Version | Date       | Description          |
+|---------|------------|----------------------|
+| 0.9.1   | 13.02.2026 | Initial draft        |
+| 1.0.0   | 22.05.2026 | Updated after review |
+```
+
+- Versions follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+- Each rulebook is versioned independently; one rulebook reaching `1.0.0` does not require others to do the same.
+- The version table is the authoritative record of changes for that rulebook.
+
+---
+
+## JSON Schemas
+
+Each JSON schema file (under `data-schemas/`) contains a top-level `version` field:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": "1.0.0",
+  ...
+}
+```
+
+- Schema versions are independent of rulebook versions and evolve at their own pace.
+- However, at major milestones and deliverables, schema versions **should be co-ordinated** to match the corresponding rulebook's major version number.
+- Minor and patch-level changes may diverge between a schema and its associated rulebook.
+
+---
+
+## VCTM Credentials
+
+Credentials in the VCTM (Verifiable Credential Type Metadata) directory are versioned by **creating a new file** and **iterating the path**, rather than editing the existing file in place. This preserves backwards compatibility for any system already referencing a specific credential path.
+
+- New credential files should only be created for **major version changes**.
+- The number of distinct credential versions should be kept to a minimum.
+- Older credential files are retained in the repository to support systems that reference them.
+
+---
+
+## Repository Tags
+
+The repository uses Git tags to mark major milestone versions aligned with WE BUILD deliverables.
+
+- A tag (e.g. `v1.0`) represents a snapshot of the entire repository at a point in time.
+- A tag **does not imply** that all artefacts within the repository share the same version number; individual rulebooks, schemas, and credentials may be at different versions.
+- Tags are used primarily to provide a stable reference point for project deliverables.

--- a/data-schemas/sd-jwt/ds002-pid-sd-jwt.json
+++ b/data-schemas/sd-jwt/ds002-pid-sd-jwt.json
@@ -9,10 +9,9 @@
   "properties": {
     "vct": {
       "type": "string",
-      "description": "Verifiable Credential Type. Base type is 'urn:eudi:pid:1'. Domestic types MAY be of the form 'urn:eudi:pid:<cc>:1'.",
+      "description": "Verifiable Credential Type. Base type is 'urn:eudi:pid:1'.",
       "examples": [
-        "urn:eudi:pid:1",
-        "urn:eudi:pid:de:1"
+        "urn:eudi:pid:1"
       ]
     },
     "given_name": {

--- a/data-schemas/sd-jwt/ds004-eucc-sd-jwt.json
+++ b/data-schemas/sd-jwt/ds004-eucc-sd-jwt.json
@@ -8,10 +8,9 @@
   "properties": {
     "vct": {
       "type": "string",
-      "description": "Verifiable Credential Type. Base type is 'uri:eu:eudi:eucc:1'. Domestic types MAY be of the form 'uri:eu:eudi:eucc:<cc>:1'.",
+      "description": "Verifiable Credential Type. Base type is 'uri:eudi:eucc:1'.",
       "examples": [
-        "uri:eu:eudi:eucc:1",
-        "uri:eu:eudi:eucc:de:1"
+        "uri:eudi:eucc:1"
       ]
     },
     "issuing_authority": {

--- a/data-schemas/sd-jwt/ds004-eucc-sd-jwt.json
+++ b/data-schemas/sd-jwt/ds004-eucc-sd-jwt.json
@@ -1,16 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "EWC - EU Company Certificate",
-  "description": "Schema for EU Company Certificate - EWC WP3",
+  "title": "WE BUILD - EU Company Certificate",
+  "description": "Schema for EU Company Certificate - WE BUILD",
   "type": "object",
+  "version": "0.9.0",
   "additionalProperties": false,
   "properties": {
     "vct": {
       "type": "string",
-      "description": "Verifiable Credential Type. Base type is 'urn:eudi:eucc:1'. Domestic types MAY be of the form 'urn:eudi:eucc:<cc>:1'.",
+      "description": "Verifiable Credential Type. Base type is 'uri:eu:eudi:eucc:1'. Domestic types MAY be of the form 'uri:eu:eudi:eucc:<cc>:1'.",
       "examples": [
-        "urn:eudi:eucc:1",
-        "urn:eudi:eucc:de:1"
+        "uri:eu:eudi:eucc:1",
+        "uri:eu:eudi:eucc:de:1"
       ]
     },
     "issuing_authority": {
@@ -25,10 +26,6 @@
       "description": "Alpha-2 country code, as defined in ISO 3166-1, of the issuing country or territory.",
       "type": "string",
       "pattern": "^[A-Z]{2}$"
-    },
-    "issuing_jurisdiction": {
-      "description": "As defined in ISO 3166-2:2020, of the issuing country or territory.",
-      "type": "string"
     },
     "issuance_date": {
       "description": "Date and possibly time of issuance",
@@ -380,6 +377,7 @@
     }
   },
   "required": [
+    "attestation_legal_category",
     "legal_person_name",
     "legal_person_id",
     "legal_form_type",
@@ -391,7 +389,6 @@
     "issuing_authority",
     "issuing_authority_id",
     "issuing_country",
-    "issuance_date",
     "authentic_source_id",
     "authentic_source_name",
     "legal_representative"
@@ -400,10 +397,24 @@
     "legal_representative": {
       "oneOf": [
         {
-          "$ref": "#/$defs/legal_representative.natural_person"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "natural_person": {
+              "$ref": "#/$defs/legal_representative.natural_person"
+            }
+          },
+          "required": ["natural_person"]
         },
         {
-          "$ref": "#/$defs/legal_representative.legal_person"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "legal_person": {
+              "$ref": "#/$defs/legal_representative.legal_person"
+            }
+          },
+          "required": ["legal_person"]
         }
       ]
     },
@@ -426,11 +437,14 @@
           "type": "string"
         },
         "signatory_rule": {
-          "description": "Information if the representative can engage the company alone or jointly",
+          "description": "Information on whether the representative can engage the company alone or jointly",
           "type": "string",
           "enum": [
-            "alone",
-            "joint"
+            "sole",
+            "joint",
+            "joint_two",
+            "joint_all",
+            "limited"
           ]
         }
       },
@@ -458,11 +472,14 @@
           "type": "string"
         },
         "signatory_rule": {
-          "description": "Information if the representative can engage the company alone or jointly",
+          "description": "Information on whether the representative can engage the company alone or jointly",
           "type": "string",
           "enum": [
-            "alone",
-            "joint"
+            "sole",
+            "joint",
+            "joint_two",
+            "joint_all",
+            "limited"
           ]
         }
       },

--- a/data-schemas/sd-jwt/sample-data/ds002-pid-sd-jwt-sample.json
+++ b/data-schemas/sd-jwt/sample-data/ds002-pid-sd-jwt-sample.json
@@ -1,5 +1,5 @@
 {
-  "vct": "urn:eudi:pid:de:1",
+  "vct": "urn:eudi:pid:1",
   "attestation_legal_category": "PUB-EAA",
   "given_name": "Jean",
   "family_name": "Dupont",

--- a/data-schemas/sd-jwt/sample-data/ds004-eucc-sd-jwt-sample.json
+++ b/data-schemas/sd-jwt/sample-data/ds004-eucc-sd-jwt-sample.json
@@ -1,10 +1,9 @@
 {
-  "vct": "uri:eu.eudi.eucc.1",
+  "vct": "uri:eu:eudi:eucc:1",
   "attestation_legal_category": "QEAA",
   "issuing_authority": "Brønnøysundregistrene",
   "issuing_authority_id": "974760673",
   "issuing_country": "NO",
-  "issuing_jurisdiction": "NO",
   "issuance_date": "2026-01-15T10:00:00Z",
   "authentic_source_id": "974760673",
   "authentic_source_name": "Brønnøysundregistrene",
@@ -37,16 +36,20 @@
   },
   "legal_representative": [
     {
-      "full_name": "Lysende Blomst",
-      "date_of_birth": "1980-01-01",
-      "nationality": "Norwegian",
-      "signatory_rule": "alone"
+      "natural_person": {
+        "full_name": "Lysende Blomst",
+        "date_of_birth": "1980-01-01",
+        "nationality": "Norwegian",
+        "signatory_rule": "sole"
+      }
     },
     {
-      "name": "PARENT HOLDING AS",
-      "id": "NOFOR.123456789",
-      "legal_form_type": "Aksjeselskap (AS)",
-      "signatory_rule": "alone"
+      "legal_person": {
+        "name": "PARENT HOLDING AS",
+        "id": "NOFOR.123456789",
+        "legal_form_type": "Aksjeselskap (AS)",
+        "signatory_rule": "sole"
+      }
     }
   ],
   "trust_anchor": "https://trust.example.org/anchors/eidas",

--- a/data-schemas/sd-jwt/sample-data/ds004-eucc-sd-jwt-sample.json
+++ b/data-schemas/sd-jwt/sample-data/ds004-eucc-sd-jwt-sample.json
@@ -1,5 +1,5 @@
 {
-  "vct": "uri:eu:eudi:eucc:1",
+  "vct": "uri:eudi:eucc:1",
   "attestation_legal_category": "QEAA",
   "issuing_authority": "Brønnøysundregistrene",
   "issuing_authority_id": "974760673",

--- a/rulebooks/rb-eucc/README.md
+++ b/rulebooks/rb-eucc/README.md
@@ -17,10 +17,11 @@
 
 *Provide versioning information about the Rulebook in the following form:*
 
-| Version          | Date               | Description                                      |
-|------------------|--------------------|--------------------------------------------------|
-| 01                | 12.01.2025         | Initial Draft based on the previous [work of EWC ](https://github.com/EWC-consortium/eudi-wallet-rulebooks-and-schemas/blob/main/rulebooks/rb002_eu_company_certificate.md) |
-| 02                | 10.04.2026         | Updated according to the work done in WE BUILD, using the [WE BUILD EUCC attestation description](https://portal.webuildconsortium.eu/group/bu2-create-company-branch/files?mid=7087&fid%5B0%5D=56&fid%5B1%5D=58&fid%5B2%5D=62) |
+| Version | Date       | Description                                                                                                                                                                                                                     |
+|---------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 01      | 12.01.2025 | Initial Draft based on the previous [work of EWC ](https://github.com/EWC-consortium/eudi-wallet-rulebooks-and-schemas/blob/main/rulebooks/rb002_eu_company_certificate.md)                                                     |
+| 02      | 10.04.2026 | Updated according to the work done in WE BUILD, using the [WE BUILD EUCC attestation description](https://portal.webuildconsortium.eu/group/bu2-create-company-branch/files?mid=7087&fid%5B0%5D=56&fid%5B1%5D=58&fid%5B2%5D=62) |
+| 03      | 22.06.2026 | Definition of new required fields to align the rulebook with VCTM.                                                                                                                                                              |
 
 **Feedback:**
 Main feedback channel: [GitHub issues](https://github.com/webuild-consortium/eudi-wallet-rulebooks-and-schemas/issues)
@@ -259,11 +260,14 @@ There is currently no open standard for addresses. As such, the definitions from
 
 ### 2.6 Mandatory metadata 
 
-| **Data Identifier**  | **Definition**                                                                                                                                                                                           |
-|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| expiry_date          | Date (and if possible time) when the attestation will expire. Does not need to be an atribute and can be covered by credentialformat metadata, such as for example the "exp" field on the sd-jwt format. |
-| issuing_authority    | Name of the administrative authority that issued the eucc, or the ISO 3166 alpha-2 country code of the respective Member State if there is no separate authority entitled to issue the EUCC.             |
-| issuing_country      | Alpha-2 country code, as specified in ISO 3166-1, of the country or territory of the provider of the person identification data.                                                                         |
+| **Data Identifier**   | **Definition**                                                                                                                                                                               |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| expiry_date           | Date (and if possible time) when the attestation will expire.                                                                                                                                |
+| issuing_authority     | Name of the administrative authority that issued the eucc, or the ISO 3166 alpha-2 country code of the respective Member State if there is no separate authority entitled to issue the EUCC. |
+| issuing_authority _id | EUID or equivalent identifier of the issuing authority                                                                                                                                       |
+| issuing_country       | Alpha-2 country code, as specified in ISO 3166-1, of the country or territory of the provider of the person identification data.                                                             |
+| authentic_source_name | Name of the authentic source                                                                                                                                                                 |
+| authentic_source_id   | EUID or equivalent identifier of the authentic source                                                                                                                                        |
 
 ### 2.7 Conditional metadata 
 
@@ -289,55 +293,58 @@ Selective Disclosure: Claims of EUCC SHALL NOT be selectively disclosable to pre
 The . notation is used to indicate the nesting of attributes.
 
 
-**Verifiable Credential Type (`vct`):** `uri:eu.eudi.eucc.1`
+**Verifiable Credential Type (`vct`):** `uri:eu:eudi:eucc:1`
 
 
-| **Data Identifier**                                | **Attribute identifier**                          | **Encoding format** | **Reference/Notes**                                                        |
-|----------------------------------------------------|---------------------------------------------------|---------------------|----------------------------------------------------------------------------|
-| attestation_legal_category                         | attestation_legal_category                        | string              | One of EAA, Pub-EAA, QEAA as defined by eIDAS 2                            |
-| issuing_authority                                  | iss                                               | string              | RFC 7519 / Section 2.6                                                     |
-| expiry_date                                        | exp                                               | number              | RFC 7519 / Section 2.6 (Unix timestamp)                                    |
-| issuing_country                                    | issuing_country                                   | string              | ISO 3166-1 alpha-2                                                         |
-| legal_person_name                                  | legal_person_name                                 | string              | Official current legal person name as registered in the business register. |
-| legal_person_id                                    | legal_person_id                                   | string              | EUID                                                                       |
-| legal_form_type                                    | legal_form_type                                   | string              | Legal form of the company.                                                 |
-| registration_member_state                          | registration_member_state                         | string              | The member state where the company is registered (Alpha-2 country code).   |
-| registration_date                                  | registration_date                                 | string              | ISO 8601 (YYYY-MM-DD)                                                      |
-| legal_person_status                                | legal_person_status                               | string              |                                                                            |
-| legal_person_activity                              | legal_person_activity                             | object              | The NACE code describing the main activity                                 |
-| legal_person_activity.code                         | legal_person_activity.code                        | string              |                                                                            |
-| legal_person_activity.description                  | legal_person_activity.description                 | string              |                                                                            |
-| legal_person_duration                              | legal_person_duration                             | date                | Given as date following ISO 8601                                           |
-| registered_address                                 | registered_address                                | object              | See section 2.5 for structure                                              |
-| registered_address.full_address                    | registered_address.full_address                   | string              |                                                                            |
-| registered_address.care_of                         | registered_address.care_of                        | string              |                                                                            |
-| registered_address.thorough_fare                   | registered_address.thorough_fare                  | string              |                                                                            |
-| registered_address.locator_designator              | registered_address.locator_designator             | string              |                                                                            |
-| registered_address.post_code                       | registered_address.post_code                      | string              |                                                                            |
-| registered_address.post_name                       | registered_address.post_name                      | string              |                                                                            |
-| registered_address.post_office_box                 | registered_address.post_office_box                | string              |                                                                            |
-| registered_address.locator_name                    | registered_address.locator_name                   | string              |                                                                            |
-| registered_address.admin_unit_level_1              | registered_address.admin_unit_level_1             | string              |                                                                            |
-| registered_address.admin_unit_level_2              | registered_address.admin_unit_level_2             | string              |                                                                            |
-| legal_representative                               | legal_representative                              | array               | Array of natural/legal persons                                             |
-| legal_representative.legal_person                  | legal_representative.legal_person                 | object              |                                                                            |
-| legal_representative.legal_person.name             | legal_representative.legal_person.name            | string              |                                                                            |
-| legal_representative.legal_person.id               | legal_representative.legal_person.id              | string              |                                                                            |
-| legal_representative.legal_person.formtype         | legal_representative.legal_person.formtype        | string              |                                                                            |
-| legal_representative.legal_person.signatory_rule   | legal_representative.legal_person.signatory_rule  | string              |                                                                            |
-| legal_representative.natural_person                | legal_representative.natural_person               | object              |                                                                            |
-| legal_representative.natural_person.full_name      | legal_representative.natural_person.full_name     | string              |                                                                            |
-| legal_representative.natural_person.identifier | legal_representative.natural_person.identifier | string | Natural person representative identifier |
-| legal_representative.natural_person.date_of_birth  | legal_representative.natural_person.date_of_birth | string              |                                                                            |
-| legal_representative.natural_person.nationality    | legal_representative.natural_person.nationality   | string              |                                                                            |
-| legal_representative.natural_person.signatory_rule | legal_representative.natural_person.signatory_rule | string   |                                                                            |
-| share_capital                                      | share_capital                                     | object              |                                                                            |
-| share_capital.amount                               | share_capital.amount                              | string              |                                                                            |
-| share_capital.currency                             | share_capital.currency                            | string              |                                                                            |
-| digital_contact_point                              | digital_contact_point                             | object              |                                                                            |
-| digital_contact_point.website                      | digital_contact_point.website                     | string              |                                                                            |
-| digital_contact_point.email                        | digital_contact_point.email                       | string              |                                                                            |
-| location_status                                    | status                                            | object              | See chapter [3.2.3](#321-attribute-status)                                 |
+| **Data Identifier**                                | **Attribute identifier**                           | **Encoding format** | **Reference/Notes**                                                        |
+|----------------------------------------------------|----------------------------------------------------|---------------------|----------------------------------------------------------------------------|
+| attestation_legal_category                         | attestation_legal_category                         | string              | One of EAA, Pub-EAA, QEAA as defined by eIDAS 2                            |
+| issuing_authority                                  | issuing_authority                                  | string              | RFC 7519 / Section 2.6                                                     |
+| issuing_authority_id                               | issuing_authority_id                               | string              | EUID or equivalent identifier of the issuing authority                     |
+| authentic_source_name                              | authentic_source_name                              | string              |                                                                            |
+| authentic_source_id                                | authentic_source_id                                | string              |                                                                            |
+| expiry_date                                        | expiry_date                                        | string              |                                                                            |
+| issuing_country                                    | issuing_country                                    | string              | ISO 3166-1 alpha-2                                                         |
+| legal_person_name                                  | legal_person_name                                  | string              | Official current legal person name as registered in the business register. |
+| legal_person_id                                    | legal_person_id                                    | string              | EUID                                                                       |
+| legal_form_type                                    | legal_form_type                                    | string              | Legal form of the company.                                                 |
+| registration_member_state                          | registration_member_state                          | string              | The member state where the company is registered (Alpha-2 country code).   |
+| registration_date                                  | registration_date                                  | string              | ISO 8601 (YYYY-MM-DD)                                                      |
+| legal_person_status                                | legal_person_status                                | string              |                                                                            |
+| legal_person_activity                              | legal_person_activity                              | object              | The NACE code describing the main activity                                 |
+| legal_person_activity.code                         | legal_person_activity.code                         | string              |                                                                            |
+| legal_person_activity.description                  | legal_person_activity.description                  | string              |                                                                            |
+| legal_person_duration                              | legal_person_duration                              | date                | Given as date following ISO 8601                                           |
+| registered_address                                 | registered_address                                 | object              | See section 2.5 for structure                                              |
+| registered_address.full_address                    | registered_address.full_address                    | string              |                                                                            |
+| registered_address.care_of                         | registered_address.care_of                         | string              |                                                                            |
+| registered_address.thorough_fare                   | registered_address.thorough_fare                   | string              |                                                                            |
+| registered_address.locator_designator              | registered_address.locator_designator              | string              |                                                                            |
+| registered_address.post_code                       | registered_address.post_code                       | string              |                                                                            |
+| registered_address.post_name                       | registered_address.post_name                       | string              |                                                                            |
+| registered_address.post_office_box                 | registered_address.post_office_box                 | string              |                                                                            |
+| registered_address.locator_name                    | registered_address.locator_name                    | string              |                                                                            |
+| registered_address.admin_unit_level_1              | registered_address.admin_unit_level_1              | string              |                                                                            |
+| registered_address.admin_unit_level_2              | registered_address.admin_unit_level_2              | string              |                                                                            |
+| legal_representative                               | legal_representative                               | array               | Array of natural/legal persons                                             |
+| legal_representative.legal_person                  | legal_representative.legal_person                  | object              |                                                                            |
+| legal_representative.legal_person.name             | legal_representative.legal_person.name             | string              |                                                                            |
+| legal_representative.legal_person.id               | legal_representative.legal_person.id               | string              |                                                                            |
+| legal_representative.legal_person.legal_form_type  | legal_representative.legal_person.legal_form_type  | string              |                                                                            |
+| legal_representative.legal_person.signatory_rule   | legal_representative.legal_person.signatory_rule   | string              |                                                                            |
+| legal_representative.natural_person                | legal_representative.natural_person                | object              |                                                                            |
+| legal_representative.natural_person.full_name      | legal_representative.natural_person.full_name      | string              |                                                                            |
+| legal_representative.natural_person.identifier     | legal_representative.natural_person.identifier     | string              | Natural person representative identifier                                   |
+| legal_representative.natural_person.date_of_birth  | legal_representative.natural_person.date_of_birth  | string              |                                                                            |
+| legal_representative.natural_person.nationality    | legal_representative.natural_person.nationality    | string              |                                                                            |
+| legal_representative.natural_person.signatory_rule | legal_representative.natural_person.signatory_rule | string              |                                                                            |
+| share_capital                                      | share_capital                                      | object              |                                                                            |
+| share_capital.amount                               | share_capital.amount                               | string              |                                                                            |
+| share_capital.currency                             | share_capital.currency                             | string              |                                                                            |
+| digital_contact_point                              | digital_contact_point                              | object              |                                                                            |
+| digital_contact_point.website                      | digital_contact_point.website                      | string              |                                                                            |
+| digital_contact_point.email                        | digital_contact_point.email                        | string              |                                                                            |
+| location_status                                    | status                                             | object              | See chapter [3.2.3](#321-attribute-status)                                 |
 
 
 #### 3.2.1 Attribute status

--- a/rulebooks/rb-eucc/README.md
+++ b/rulebooks/rb-eucc/README.md
@@ -293,7 +293,7 @@ Selective Disclosure: Claims of EUCC SHALL NOT be selectively disclosable to pre
 The . notation is used to indicate the nesting of attributes.
 
 
-**Verifiable Credential Type (`vct`):** `uri:eu:eudi:eucc:1`
+**Verifiable Credential Type (`vct`):** `uri:eudi:eucc:1`
 
 
 | **Data Identifier**                                | **Attribute identifier**                           | **Encoding format** | **Reference/Notes**                                                        |

--- a/rulebooks/rb-pid/README.md
+++ b/rulebooks/rb-pid/README.md
@@ -160,9 +160,9 @@ The PID defined in this rulebook does not contain any condition attributes.
 
 
 ### 2.7 Additional mandatory attributes specified in this Rulebook
-| **Data Identifier**        | **Definition**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | **Example value**                       |
-|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
-| attestation_legal_category | This attribute indicates that a PID has indeed been issued as a PID. *Note: According to Annex V point a) and Annex VII point a) of the [European Digital Identity Regulation] an indication, at least in a form suitable for automated processing, that the attestation has been issued as a QEAA or Pub-EAA SHALL be defined. This PID Rulebook adds this as an optional attribute for PIDs as well, so PID Providers are able to ensure that PIDs can be validated by Relying Parties in the same manner as QEAAs.*              | PID                                     |
+| **Data Identifier**        | **Definition**                                                                                                                                                                                                                                                                                                                   | **Example value** |
+|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| attestation_legal_category | This attribute indicates that a PID has indeed been issued as a PID. *Note: According to Annex V point a) and Annex VII point a) of the [European Digital Identity Regulation] an indication, at least in a form suitable for automated processing, that the attestation has been issued as a QEAA or Pub-EAA SHALL be defined.* | PID               |
 
 ### 2.7 Additional optional attributes specified in this Rulebook
 
@@ -410,7 +410,7 @@ EXAMPLE: The following example shows the payload of a PID in SD-JWT VC format be
 
 ```json
 {
-    "vct": "urn:eudi:pid:de:1",
+    "vct": "urn:eudi:pid:1",
     "attestation_legal_category": "PID",
 
     "given_name": "Jean",

--- a/rulebooks/rb-pid/README.md
+++ b/rulebooks/rb-pid/README.md
@@ -159,13 +159,18 @@ The PID defined in this rulebook does not contain any condition attributes.
 | location_status      | The location of validity status information on the person identification data where the providers of person identification data revoke person identification data.                                                     | <https://example.com/statuslists/pid/> |
 
 
+### 2.7 Additional mandatory attributes specified in this Rulebook
+| **Data Identifier**        | **Definition**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | **Example value**                       |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| attestation_legal_category | This attribute indicates that a PID has indeed been issued as a PID. *Note: According to Annex V point a) and Annex VII point a) of the [European Digital Identity Regulation] an indication, at least in a form suitable for automated processing, that the attestation has been issued as a QEAA or Pub-EAA SHALL be defined. This PID Rulebook adds this as an optional attribute for PIDs as well, so PID Providers are able to ensure that PIDs can be validated by Relying Parties in the same manner as QEAAs.*              | PID                                     |
+
 ### 2.7 Additional optional attributes specified in this Rulebook
 
 | **Data Identifier**        | **Definition**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | **Example value**                       |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
 | issuance_date              | Date (and if possible time) when the person identification data was issued and/or the administrative validity period of the person identification data began. See also the clarification for expiry_date in [Section 2.5](#25-mandatory-metadata-specified-in-cir-20242977).                                                                                                                                                                                                                                                        | 19-12-2025                              |
 | trust_anchor               | This attribute indicates at least the URL at which a machine-readable version of the trust anchor to be used for verifying the PID can be found or looked up. *Note: This attribute corresponds to the location meant in Annex V point h) or Annex VII point h) of the [European Digital Identity Regulation], which is mandatory for QEAAs. This PID Rulebook adds this as an optional attribute for PIDs as well, so PID Providers are able to ensure that PIDs can be validated by Relying Parties in the same manner as QEAAs.* | <https://example.com/trustanchors/pid/> |
-| attestation_legal_category | This attribute indicates that a PID has indeed been issued as a PID. *Note: According to Annex V point a) and Annex VII point a) of the [European Digital Identity Regulation] an indication, at least in a form suitable for automated processing, that the attestation has been issued as a QEAA or Pub-EAA SHALL be defined. This PID Rulebook adds this as an optional attribute for PIDs as well, so PID Providers are able to ensure that PIDs can be validated by Relying Parties in the same manner as QEAAs.*              | PID                                     |
+
 
 # 3 Attestation encoding
 
@@ -406,7 +411,7 @@ EXAMPLE: The following example shows the payload of a PID in SD-JWT VC format be
 ```json
 {
     "vct": "urn:eudi:pid:de:1",
-    "attestation_legal_category": "PUB-EAA",
+    "attestation_legal_category": "PID",
 
     "given_name": "Jean",
     "family_name": "Dupont",

--- a/sample-data/ds002-pid-sd-jwt-sample.json
+++ b/sample-data/ds002-pid-sd-jwt-sample.json
@@ -1,5 +1,5 @@
 {
-  "vct": "urn:eudi:pid:de:1",
+  "vct": "urn:eudi:pid:1",
   "attestation_legal_category": "PUB-EAA",
 
   "given_name": "Jean",

--- a/vctm/README.md
+++ b/vctm/README.md
@@ -1,0 +1,25 @@
+# VCTM — Verifiable Credential Type Metadata
+
+## What is VCTM?
+
+**VCTM** (Verifiable Credential Type Metadata) is a standardised format for describing the structure, display properties, and claims of a Verifiable Credential type. A VCTM definition captures everything a verifier or wallet needs to understand a credential: its type identifier (VCT URI), the claims it contains, their types and display names, selective-disclosure settings, and visual rendering hints such as background and text colours.
+
+## Files in this folder
+
+Each credential type in this folder consists of:
+
+| File                      | Purpose |
+|---------------------------|---------|
+| `<attestation-slug>.md`   | Markdown source defining the credential (front matter + claims) |
+| `<attestation-slug>.schema-meta.yaml` | Sidecar metadata (rulebook URI, LoS, binding type, trusted authorities) |
+
+## Registry
+
+Published credential types are listed in the **Siros Credential Type Registry**:
+
+**[https://registry.siros.org](https://registry.siros.org)**
+
+## Documentation
+
+- **How to register your credential type:** [https://registry.siros.org/docs/register.html](https://registry.siros.org/docs/register.html)
+- **Markdown format reference (syntax for defining claims, display names, localisation, etc.):** [https://registry.siros.org/docs/markdown-format.html](https://registry.siros.org/docs/markdown-format.html)

--- a/vctm/ebwoid.md
+++ b/vctm/ebwoid.md
@@ -1,0 +1,22 @@
+---
+vct: urn:eu:ebw:oid:1
+background_color: "#003087"
+text_color: "#ffffff"
+formats:
+  - "sd-jwt"
+  - "w3c"
+---
+
+# European Business Wallet – Owner Identification Data (EBW-OID)
+
+A verifiable credential that uniquely identifies an EBW owner (economic operator or public sector body) within the European Business Wallets ecosystem. Issued as a Pub-EAA or QEAA in accordance with the European Digital Identity Regulation and the EBW proposal (COM 2025/838).
+
+## Claims
+
+- `id` "Business Identifier" (string): EUID where available, otherwise a similar constructed unique per-issuer identifier [mandatory] [sd=never]
+- `name` "Legal Name" (string): Official name of the EBW owner (economic operator or public sector body) [mandatory] [sd=never]
+- `attestation_legal_category` "Attestation Legal Category" (string): Legal category of the attestation; QEAA or PUB-EAA [mandatory] [sd=never]
+- `date_of_expiry` "Expiry Date" (date): Administrative expiry date in ISO 8601 YYYY-MM-DD format [sd=never]
+- `issuing_authority` "Issuing Authority" (string): Name of the administrative authority that issued the EBW-OID [mandatory] [sd=never]
+- `issuing_country` "Issuing Country" (string): Alpha-2 country code of the provider's country or territory [mandatory] [sd=never]
+- `trust_anchor` "Trust Anchor" (string): URL of the machine-readable trust anchor for verifying the EBW-OID [sd=never]

--- a/vctm/ebwoid.schema-meta.yaml
+++ b/vctm/ebwoid.schema-meta.yaml
@@ -1,0 +1,6 @@
+attestation_los: iso_18045_high
+binding_type: key
+rulebook_uri: https://github.com/webuild-consortium/webuild-attestation-rulebooks-catalog/blob/main/rulebooks/rb-ebwoid/README.md
+trusted_authorities:
+  - framework_type: etsi_tl
+    value: https://tl.eidas.europa.eu/tl-browser/#/

--- a/vctm/eucc.md
+++ b/vctm/eucc.md
@@ -1,5 +1,5 @@
 ---
-vct: urn:eu:eudi:eucc:1
+vct: urn:eudi:eucc:1
 background_color: "#1a4f8a"
 text_color: "#ffffff"
 formats: "sd-jwt, w3c"

--- a/vctm/eucc.md
+++ b/vctm/eucc.md
@@ -1,0 +1,57 @@
+---
+vct: urn:eu:eudi:eucc:1
+background_color: "#1a4f8a"
+text_color: "#ffffff"
+formats: "sd-jwt, w3c"
+---
+
+# EU Company Certificate (EUCC)
+
+A verifiable credential attesting to the legal existence and registration details of a legal person within the EU, as defined in the EUCC Rulebook.
+
+## Claims
+
+- `legal_person_name` "Legal Name" (string): Official registered name of the legal person [mandatory]
+- `legal_person_id` "Legal Person Identifier" (string): Unique identifier of the legal person (e.g. EUID) [mandatory]
+- `legal_form_type` "Legal Form" (string): Legal form of the entity (e.g. Aksjeselskap (AS)) [mandatory]
+- `registration_member_state` "Registration Member State" (string): Alpha-2 country code of the mmber state where the entity is registered [mandatory]
+- `registered_address` "Registered Address" (object): Official registered address of the legal person [mandatory]
+  - `full_address` (string): Full address as a single string [mandatory]
+  - `care_of` (string): Used when the address is at the address of another person or legal person. 
+  - `thorough_fare` (string): Street name
+  - `locator_designator` (string): House number or locator
+  - `post_code` (string): Postal code
+  - `post_name` (string): City or locality
+  - `post_office_box` (string): A location designator for a postal delivery point at a post office.
+  - `locator_name` (string): Proper noun(s) applied to the real-world entity.
+  - `admin_unit_level_1` (string): Country code (ISO 3166-1 alpha-2)
+  - `admin_unit_level_2` (string): Region or county
+- `registration_date` "Registration Date" (date): Date of registration in ISO 8601 YYYY-MM-DD format [mandatory]
+- `legal_person_status` "Legal Person Status" (string): Current status of the legal person (e.g. active) [mandatory]
+- `legal_person_activity` "Legal Person Activity" (object): Primary business activity [mandatory]
+  - `code` (string): Activity code (e.g. NACE) [mandatory]
+  - `description` (string): Description of the activity [mandatory]
+- `share_capital` "Share Capital" (object): Share capital of the legal person
+  - `amount` (string): Amount of share capital
+  - `currency` (string): Currency code (ISO 4217)
+- `legal_person_duration` "Legal Person Duration" (string): Duration or end date of the legal person if applicable
+- `digital_contact_point` "Digital Contact Point" (object): Digital contact information
+  - `website` (string): Website URL
+  - `email` (string): Email address
+- `legal_representative` "Legal Representatives" (array): Natural or legal person representatives authorised to represent the legal person [mandatory]
+  - `full_name` (string): Full name of the natural person representative (Mandatory if natural person represenative)
+  - `date_of_birth` (date): Date of birth of the natural person representative (Mandatory if natural person represenative)
+  - `nationality` (string): Nationality of the natural person representative (Optional if natural person represenative)
+  - `name` (string): Name of the legal person representative (Mandatory if not a natural person represenative)
+  - `id` (string): Identifier of the legal person representative (EUID or similar) (Mandatory if not a natural person represenative)
+  - `legal_form_type` (string): Legal form of the legal person representative (Mandatory if not a natural person represenative)
+  - `signatory_rule` (string): Signatory rule (e.g. alone, jointly)  [mandatory]
+- `issuing_authority` "Issuing Authority" (string): Name of the authority that issued the EUCC [mandatory] [sd=never]
+- `issuing_authority_id` (string): EUID or equivalent identifier of the issuing authority [mandatory] [sd=never]
+- `issuing_country` "Issuing Country" (string): Alpha-2 country code of the issuing authority's country [mandatory] [sd=never]
+- `issuance_date` "Issuance Date" (date): Date when the EUCC was issued in ISO 8601 format [mandatory]
+- `authentic_source_id` "Authentic Source ID" (string): Identifier of the authentic source [mandatory] [sd=never]
+- `authentic_source_name` "Authentic Source Name" (string): Name of the authentic source [mandatory] [sd=never]
+- `attestation_legal_category` "Attestation Legal Category" (string): Legal category; EBWOID [mandatory]  [sd=never]
+- `trust_anchor` "Trust Anchor" (string): URL of the machine-readable trust anchor for verifying the EUCC [sd=never]
+- `expiry_date` "Expiry Date" (date): Date when the EUCC expires in ISO 8601 format [mandatory]

--- a/vctm/eucc.schema-meta.yaml
+++ b/vctm/eucc.schema-meta.yaml
@@ -1,0 +1,6 @@
+attestation_los: iso_18045_high
+binding_type: key
+rulebook_uri: https://github.com/webuild-consortium/webuild-attestation-rulebooks-catalog/blob/main/rulebooks/rb-eucc/README.md
+trusted_authorities:
+  - framework_type: etsi_tl
+    value: https://tl.eidas.europa.eu/tl-browser/#/

--- a/vctm/pid.md
+++ b/vctm/pid.md
@@ -1,0 +1,44 @@
+---
+vct: urn:euditest:pid:1
+background_color: "#003087"
+text_color: "#ffffff"
+---
+
+# Personal Identification Data (PID)
+
+A verifiable credential that identifies a natural person within the EUDI Wallet ecosystem, as defined in CIR 2024/2977 and the ARF PID Rulebook.
+
+## Claims
+
+- `given_name` "Given Name" (string): Current first name(s), including middle name(s) where applicable [mandatory]
+- `family_name` "Family Name" (string): Current last name(s) or surname(s) [mandatory]
+- `birthdate` "Date of Birth" (date): Date of birth in ISO 8601 YYYY-MM-DD format [mandatory]
+- `place_of_birth` "Place of Birth" (object): Place where the person was born [mandatory]
+  - `country` (string): Alpha-2 country code (ISO 3166-1)
+  - `region` (string): State, province, district, or local area
+  - `locality` (string): Municipality, city, town, or village
+- `nationalities` "Nationalities" (array): One or more alpha-2 country codes (ISO 3166-1) [mandatory]
+  - (string): Alpha-2 country code
+- `address` "Address" (object): Current residence address
+  - `formatted` (string): Full mailing address, formatted for display
+  - `street_address` (string): Full street address component
+  - `house_number` (string): House number including any affix or suffix
+  - `locality` (string): City or locality component
+  - `region` (string): State, province, prefecture, or region component
+  - `postal_code` (string): Zip code or postal code component
+  - `country` (string): Country name component
+- `birth_family_name` "Family Name at Birth" (string): Last name(s) at the time of birth
+- `birth_given_name` "Given Name at Birth" (string): First name(s) at the time of birth
+- `sex` "Sex" (number): 0=not known, 1=male, 2=female, 3=other, 4=inter, 5=diverse, 6=open, 9=not applicable
+- `email` "Email Address" (string): Electronic mail address
+- `phone_number` "Mobile Phone Number" (string): Mobile telephone number in E.164 format
+- `picture` "Portrait" (image): Facial image in JPEG format as data URL
+- `personal_administrative_number` "Personal Administrative Number" (string): Unique personal administrative number assigned by the PID Provider
+- `date_of_expiry` "Expiry Date" (date): Administrative expiry date in ISO 8601 YYYY-MM-DD format [mandatory]
+- `date_of_issuance` "Issuance Date" (date): Date when the PID was issued in ISO 8601 YYYY-MM-DD format
+- `issuing_authority` "Issuing Authority" (string): Name of the administrative authority that issued the PID [mandatory]
+- `issuing_country` "Issuing Country" (string): Alpha-2 country code of the PID Provider's country [mandatory]
+- `document_number` "Document Number" (string): Number assigned by the PID Provider
+- `issuing_jurisdiction` "Issuing Jurisdiction" (string): Country subdivision code per ISO 3166-2
+- `attestation_legal_category` "Attestation Legal Category" (string): Legal category; SHALL be PID [mandatory] [sd=never]
+- `trust_anchor` "Trust Anchor" (string): URL of the machine-readable trust anchor for verifying the PID

--- a/vctm/pid.md
+++ b/vctm/pid.md
@@ -1,5 +1,5 @@
 ---
-vct: urn:euditest:pid:1
+vct: urn:eudi:pid:1
 background_color: "#003087"
 text_color: "#ffffff"
 ---

--- a/vctm/pid.schema-meta.yaml
+++ b/vctm/pid.schema-meta.yaml
@@ -1,0 +1,6 @@
+attestation_los: iso_18045_high
+binding_type: key
+rulebook_uri: https://github.com/webuild-consortium/webuild-attestation-rulebooks-catalog/blob/main/rulebooks/rb-pid/README.md
+trusted_authorities:
+  - framework_type: etsi_tl
+    value: https://tl.eidas.europa.eu/tl-browser/#/


### PR DESCRIPTION
As decided in Amsterdam to use registry.siros.org. 

This PR includes necessary files for the credentials to be populated in the attestation catalog. 

Also, necessary changes and alignment work to keep formatting consistent across all credential types, as the vctm default formatting is slightly opinionated. 
