### PR TITLE
Add VAT ID SD-JWT sample data JSON file

### DIFF
--- a/data-schemas/sd-jwt/sample-data/vat-id-sd-jwt-sample.json
+++ b/data-schemas/sd-jwt/sample-data/vat-id-sd-jwt-sample.json
@@ -1,0 +1,141 @@
+{
+  "metadata": {
+    "title": "SD-JWT VC Example for VAT ID Attestation",
+    "credential_type": "uri:eu.eudi.vat.1",
+    "format": "SD-JWT VC",
+    "issuer": "https://www.belastingdienst.nl"
+  },
+
+  "jose_header": {
+    "alg": "ES256",
+    "typ": "vc+sd-jwt",
+    "kid": "https://www.belastingdienst.nl/keys/vat-issuer-2024-01"
+  },
+
+  "payload": {
+    "vct": "uri:eu.eudi.vat.1",
+    "iss": "https://www.belastingdienst.nl",
+    "iat": 1704067200,
+    "exp": 1830902400,
+
+    "vat_id": "NL001234567B01",
+    "administrative_unit_name": "KLM Royal Dutch Airlines",
+    "registered_EU_cross_border_transactions": true,
+
+    "validity_period": [
+      {
+        "start_date": "2020-01-15",
+        "end_date": "2027-12-31"
+      }
+    ],
+
+    "economic_operator": {
+      "legal_identifier": "NL801234567B01",
+      "legal_name": "KLM Royal Dutch Airlines N.V."
+    },
+
+    "issuer": {
+      "authentic_source_country": "NL",
+      "vat_id_authentic_source": "Ministerie van Financiën - Belastingdienst",
+      "issuing_authority": "Dutch Tax Administration",
+      "attestation_legal_category": "PUB-EAA",
+      "attestation_issuing_date": 1704067200,
+      "attestation_expiry_date": 1830902400,
+      "location_status": "https://www.belastingdienst.nl/vat-status/NL001234567B01",
+      "trust_anchor": "https://www.belastingdienst.nl/trust-anchor/vat-id-2024"
+    },
+
+    "status": {
+      "status_list_credential": "https://www.belastingdienst.nl/status-list/vat-id/2024",
+      "status_list_index": 12547,
+      "status_purpose": "revocation"
+    },
+
+    "_sd": [
+      "hash_admin_type",
+      "hash_admin_address",
+      "hash_activity",
+      "hash_validity"
+    ],
+    "sd_hash": "sha-256"
+  },
+
+  "selectively_disclosable_claims": {
+    "administrative_unit_type": {
+      "salt": "salt1",
+      "value": "N.V.",
+      "claim_name": "administrative_unit_type",
+      "sha256_digest": "hash_admin_type"
+    },
+
+    "administrative_unit_address": {
+      "salt": "salt2",
+      "value": {
+        "thoroughfare": "Amsterdamse Ring 2",
+        "location_designator": "Building A",
+        "post_code": "1101 DA",
+        "post_name": "Amsterdam",
+        "admin_unit_l1": "North Holland",
+        "admin_unit_l2": "Amsterdam"
+      },
+      "claim_name": "administrative_unit_address",
+      "sha256_digest": "hash_admin_address"
+    },
+
+    "economic_activity_type": {
+      "salt": "salt3",
+      "value": [
+        {
+          "nomenclature": "NACE",
+          "id": "51.1",
+          "description": [
+            {
+              "language": "en",
+              "value": "Passenger air transport"
+            },
+            {
+              "language": "nl",
+              "value": "Luchtvervoer van passagiers"
+            }
+          ]
+        }
+      ],
+      "claim_name": "economic_activity_type",
+      "sha256_digest": "hash_activity"
+    },
+
+    "validity_period": {
+      "salt": "salt4",
+      "value": [
+        {
+          "start_date": "2020-01-15",
+          "end_date": "2027-12-31"
+        }
+      ],
+      "claim_name": "validity_period",
+      "sha256_digest": "hash_validity"
+    }
+  },
+
+  "holder_presentation_example": {
+    "vat_id": "NL001234567B01",
+    "administrative_unit_name": "KLM Royal Dutch Airlines",
+
+    "validity_period": [
+      {
+        "start_date": "2020-01-15",
+        "end_date": "2027-12-31"
+      }
+    ],
+
+    "issuer": {
+      "issuing_authority": "Dutch Tax Administration",
+      "attestation_legal_category": "PUB-EAA"
+    },
+
+    "status": {
+      "status_list_credential": "https://www.belastingdienst.nl/status-list/vat-id/2024",
+      "status_list_index": 12547
+    }
+  }
+}


### PR DESCRIPTION
Added a sample JSON file for SD-JWT VC example related to VAT ID attestation, including metadata, JOSE header, payload, selectively disclosable claims, and holder presentation example.