### PR TITLE
Add SCA-Card (DPC) attestation rulebook and data schemas

### DIFF
--- a/data-schemas/display/sample-data/sca-card-dpc-display-meta-sample.json
+++ b/data-schemas/display/sample-data/sca-card-dpc-display-meta-sample.json
@@ -1,0 +1,38 @@
+{
+  "card": {
+    "type": {
+      "code": "DEBIT",
+      "label": "Debit Card"
+    },
+    "last_four": "4444",
+    "card_art": [
+      {
+        "theme": "DEFAULT",
+        "image_url": "https://bank.example/card.png"
+      }
+    ],
+    "issuer": {
+      "branding": {
+        "name": "Partner Bank",
+        "logo": [
+          {
+            "theme": "DEFAULT",
+            "image_url": "https://bank.example/logo.png"
+          }
+        ]
+      }
+    },
+    "network_branding": {
+      "network": "mastercard",
+      "branding": {
+        "name": "Mastercard",
+        "logo": [
+          {
+            "theme": "DEFAULT",
+            "image_url": "https://mastercard.example/logo.png"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/data-schemas/display/sca-card-dpc-display-meta.schema.json
+++ b/data-schemas/display/sca-card-dpc-display-meta.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://webuildconsortium.eu/sca/sca-card-dpc/1.0/display-meta",
+  "title": "WE BUILD SCA-Card (DPC) display meta-data",
+  "description": "Unsigned display meta-data object delivered with an SCA-Card (DPC) attestation in the display array of the OpenID4VCI credential offer and/or credential response. Derived from the EMVCo Digital Payment Credential display meta-data schema (com.emvco.dpc.card.meta); the card_group_id field is omitted because co-badged cards are out of scope for WE BUILD. This object is not part of the signed credential and is never presented to a verifier.",
+  "version": "0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["card"],
+  "properties": {
+    "card": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["last_four", "card_art"],
+      "properties": {
+        "type": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code"],
+          "properties": {
+            "code": { "type": "string", "enum": ["CREDIT", "DEBIT", "PREPAID"] },
+            "label": { "type": "string" }
+          }
+        },
+        "last_four": { "type": "string", "pattern": "^[0-9]{4}$" },
+        "card_art": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/LogoImg" },
+          "minItems": 1
+        },
+        "alias": { "type": "string" },
+        "issuer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["branding"],
+          "properties": {
+            "branding": { "$ref": "#/$defs/Branding" },
+            "country": { "type": "string", "pattern": "^[A-Z]{2}$" },
+            "website_url": { "type": "string", "format": "uri" },
+            "support_email": { "type": "string", "format": "email" },
+            "support_phone": { "type": "string" }
+          }
+        },
+        "co_branding": { "$ref": "#/$defs/Branding" },
+        "network_branding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["network", "branding"],
+          "properties": {
+            "network": { "type": "string" },
+            "branding": { "$ref": "#/$defs/Branding" }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "LogoImg": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["theme", "image_url"],
+      "properties": {
+        "theme": { "type": "string", "enum": ["DEFAULT", "LIGHT", "DARK"] },
+        "image_url": { "type": "string", "format": "uri" }
+      }
+    },
+    "Branding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "logo": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/LogoImg" },
+          "minItems": 1
+        }
+      }
+    }
+  }
+}

--- a/data-schemas/sd-jwt/sample-data/sca-card-dpc-sd-jwt-sample.json
+++ b/data-schemas/sd-jwt/sample-data/sca-card-dpc-sd-jwt-sample.json
@@ -1,0 +1,21 @@
+{
+  "vct": "https://issuer.bank.example/credentials/sca/card-dpc/1.0",
+  "vct#integrity": "sha256-Cp5VgPMqzU7cphGIL0aRy54scWhTiBFB1FJYDLyO94w=",
+  "extends": "https://webuildconsortium.eu/sca/sca-card-dpc/1.0",
+  "extends#integrity": "sha256-gV1X+E7n79QEHEt9AI0VY3ZbNefHhZloJhpaHoYFqKM=",
+  "iss": "https://issuer.bank.example",
+  "iat": 1772195095,
+  "exp": 1835267095,
+  "cnf": {
+    "jwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "f83OJ3D2xF4wK2Yp6tK2vNhbbX6YsJhBKt3vnDnNQfQ",
+      "y": "x_FEzRu9w4J6v7P3cu6UytzszbmWzxubUANe0yoyl9A"
+    }
+  },
+  "attestation_legal_category": "non-qualified-EAA",
+  "credential_id": "urn:uuid:9f2b7a2e-3b74-4a0d-9b1a-0e6a91f5d2c8",
+  "network": "mastercard",
+  "card_id": "mc-8c3f2d1a"
+}

--- a/data-schemas/sd-jwt/sca-card-dpc-sd-jwt.json
+++ b/data-schemas/sd-jwt/sca-card-dpc-sd-jwt.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://webuildconsortium.eu/sca/sca-card-dpc/1.0/schema",
+  "title": "WE BUILD SCA-Card (DPC) SD-JWT VC payload",
+  "description": "Resolved SD-JWT VC claim set for the WE BUILD SCA-Card (DPC) attestation, representing a digitised payment card. Derived from the EMVCo Digital Payment Credential card credential schema (com.emvco.dpc.card) with WE BUILD adaptations: URL-based VCT, attestation_legal_category, conditional nbf. The payload is open (additionalProperties true) because issued credentials also carry vct#integrity, extends and extends#integrity.",
+  "version": "0.1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["vct", "iss", "cnf", "iat", "exp", "attestation_legal_category", "credential_id", "network"],
+  "properties": {
+    "vct": { "type": "string", "format": "uri" },
+    "iss": { "type": "string", "format": "uri" },
+    "cnf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["jwk"],
+      "properties": {
+        "jwk": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["kty"],
+          "properties": {
+            "kty": { "type": "string" },
+            "kid": { "type": "string" },
+            "use": { "type": "string" },
+            "key_ops": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+            "alg": { "type": "string" },
+            "crv": { "type": "string" },
+            "x": { "type": "string" },
+            "y": { "type": "string" },
+            "n": { "type": "string" },
+            "e": { "type": "string" }
+          }
+        }
+      }
+    },
+    "iat": { "type": "integer" },
+    "exp": { "type": "integer" },
+    "nbf": { "type": "integer" },
+    "attestation_legal_category": { "type": "string", "const": "non-qualified-EAA" },
+    "credential_id": { "type": "string", "minLength": 1 },
+    "network": { "type": "string", "minLength": 1 },
+    "card_id": { "type": "string", "minLength": 1 }
+  }
+}

--- a/rulebooks/rb-sca-card-dpc/README.md
+++ b/rulebooks/rb-sca-card-dpc/README.md
@@ -1,75 +1,48 @@
 (Template version: 1.1)
 
-# WE BUILD Attestation Rulebook Template for attestations of type *SCA-Card aka DPC*
+# WE BUILD Attestation Rulebook for attestations of type *SCA-Card (DPC)*
 
 *[Based on the WE BUILD attestation description: https://portal.webuildconsortium.eu/group/wp3-technology-standards/files?mid=7109&fid%5B0%5D=6880&fid%5B1%5D=7094]*
 
-*This WE BUILD v1 template is derived from the EUDI attestation rulebook template and keeps its
-main chapter structure while adding practical author guidance and reusable placeholders.*
-
-*Provide information about the author(s) of this Rulebook in the following form:*
+*[The data model of this attestation is derived from the EMVCo specification "EMV Digital Payment Credential (DPC) - Card Credential & Display Meta-Data"]*
 
 * Author(s):
-    * [NAME SURNAME, AFFILIATION]
-    * [NAME SURNAME, AFFILIATION]
-* Previous Authors
-    * [NAME SURNAME, AFFILIATION (versions)]
-    * [NAME SURNAME, AFFILIATION (versions)]
-
-*Provide versioning information about the Rulebook in the following form:*
+    * Tomasz Błachowicz, Mastercard
 
 | Version | Date | Description |
 |---------|------------|------------|
-| [VERSION NUMBER] | [PUBLICATION DATE] | [DESCRIPTION OR LINK TO THE CHANGELOG] |
-| [VERSION NUMBER] | [PUBLICATION DATE] | [DESCRIPTION OR LINK TO THE CHANGELOG] |
-
-*Provide a contact email address and/or a link to an issue tracking system that can be used for
-providing feedback, e.g.:*
+| 0.1 | 2026-07-13 | Initial version derived from EMV DPC Card Credential & Display Meta-Data |
 
 **Feedback:**
 
-* <https://example.com/tracker>
+* Github, portal, email, Slack
 
 ## 1 Introduction
 
 ### 1.1 Document scope and purpose
 
-*Provide a concise explanation of the purpose of the defined attestation type, explicitly stating
-why it exists and what its primary objective is within the context of the EUDI Wallet ecosystem*
+SCA-Card (DPC) specifies the card-level SUA attestation described in [TS12] published by the European
+Commission. The attestation represents a digitised payment card as a verifiable credential, called a
+Digital Payment Credential (DPC), and is used for payment authentication with multi-factor
+authentication in remote commerce. It supports both authentication of a card already known to the
+merchant (for example a token on file or a recognised returning consumer) and credential discovery
+with card selection in the Wallet, which enables the authenticated guest checkout scenario.
 
-*In addition, authors SHOULD describe the attestation in plain language so that readers can quickly
-understand what it does in practice, who it is for, and in which use case(s) it is expected to be
-used. Content may be reused and refined from an existing attestation description where available.*
+The attestation follows the data minimisation principle: the signed payload identifies the payment
+instrument through opaque identifiers only and never contains the PAN or fragments of it. All
+presentation-oriented card data, such as the last four digits, card art, and branding, travels in a
+separate unsigned display meta-data object defined in this document.
 
-*When drafting this section, authors SHOULD cover at least the following points:*
-
-* What real-world fact, entitlement, role, status, or capability the attestation expresses.
-* Which issuers, holders, and relying parties are expected to use it.
-* Which use case or user journey the attestation supports.
-* Which existing attestation description, use-case document, or functional specification can be
-used as a source for copy-paste or refinement.
-* Which terminology should remain aligned with the source attestation description.
-
-[RULEBOOK AUTHOR TO DEFINE]
-
-> Example
->
-> This attestation enables a relying party to verify, in plain language, that the holder is
-> authorised to act in a specific project role. It is intended for project operators, service
-> providers, and supervisory relying parties in the WE BUILD ecosystem. The functional description
-> and actor terminology can be reused from the corresponding use-case attestation description and
-> refined here into rulebook language.
+In this document we specify attributes, allowed formats, and processing rules for this attestation.
+The data model is derived from the EMVCo Digital Payment Credential specification [EMV-DPC] and adapted
+to the WE BUILD SCA attestation family. Co-badged cards, which [EMV-DPC] supports through a per-badge
+credential model, are out of scope for WE BUILD; see Section 2.1.
 
 ### 1.2 Document structure
 
-*Provide a brief overview of the Rulebook's sections and their purpose. The main
-sections of the Rulebook SHOULD be*
-
-* Chapter 2, which describes the attestation attributes and metadata in an
-encoding-independent manner.
-* Chapter 3, which specifies how the attestation
-attributes and metadata are encoded in case the attestation complies with [ISO/IEC
-18013-5] and/or [SD-JWT VC] and/or [W3C VCDM v2.0]. Each encoding SHALL be specified in a separate section, or even in a separate chapter.
+* Chapter 2, which describes the attestation attributes and metadata in an encoding-independent manner.
+* Chapter 3, which specifies how the attestation attributes and metadata are encoded in case the attestation
+  complies with [SD-JWT VC].
 * Chapter 4, which specifies attestation usage.
 * Chapter 5, which defines how trust anchors for attestation verification can be obtained.
 * Chapter 6, which defines attestation revocation mechanisms.
@@ -77,479 +50,467 @@ attributes and metadata are encoded in case the attestation complies with [ISO/I
 
 ### 1.3 Key words
 
-*The following are the recommended keywords. Modify if necessary*
+This document uses the capitalised key words 'SHALL', 'SHOULD' and 'MAY' as specified in [RFC 2119], i.e.,
+to indicate requirements, recommendations, and options specified in this document.
 
-This document uses the capitalised key words 'SHALL', 'SHOULD' and 'MAY' as
-specified in [RFC 2119], i.e., to indicate requirements, recommendations and
-options specified in this document.
-
-In addition, 'must' (non-capitalised) is used to indicate an external
-constraint, i.e., a requirement that is not mandated by this document, but, for
-instance, by an external document. The word 'can' indicates a capability,
-whereas other words, such as 'will', and 'is' or 'are' are intended as
-statements of fact.
+In addition, 'must' (non-capitalised) is used to indicate an external constraint, i.e., a requirement that
+is not mandated by this document, but, for instance, by an external document. The word 'can' indicates a
+capability, whereas other words, such as 'will', and 'is' or 'are' are intended as statements of fact.
 
 ### 1.4 Terminology
 
-*It is recommended to use the terminology defined in Annex 1 of ARF. For example
-the following text can be used.*
-
 This document uses the terminology specified in Annex 1 of the ARF.
+
+Please note that terms credential and attestation are interchangeable for the purpose of this document.
 
 ## 2 Attestation attributes and metadata
 
-### Chapter overview and requirements
-
-*This chapter is used for defining all attributes that an
-attestation of the defined type may contain. In this section
-the attributes SHALL be defined in an encoding-independent manner (see ARB_06 in [Topic 12]).
-Each attribute can be mandatory, optional, or conditional
-and this SHALL be specified in the corresponding section (see ARB_09 in [Topic 12]).*
-
-*When attributes are defined, referring to attributes that
-already exist in a catalogue of attestation attributes
-SHOULD be considered (see ARB_07 in [Topic 12]).*
-
-*Where use-case documentation or an attestation description already defines attribute meanings,
-logical models, code lists, or integrity constraints, authors SHOULD align terminology with those
-sources and may copy and refine that material for this Rulebook.*
-
-*[Topic 12] of Annex 2 of the ARF defines the following High-Level Requirements with
-respect to the Attestation Rulebooks:*
-
-**Requirements for QEAA**
-
-* An attribute as meant in Annex V point a)  of the [European Digital Identity Regulation]
-SHALL be included (see ARB_11 in [Topic 12]). See also section 2.1.
-* One or more attributes or metadata representing the set of data meant in Annex
-V point b) of the [European Digital Identity Regulation] SHALL be included (see ARB_13 in [Topic 12])
-* One or more attributes representing the set of data meant in Annex V point c)  
-of the [European Digital Identity Regulation] SHALL be included (see ARB_16 in [Topic 12]).
-* One or more attributes or metadata representing the set of data meant in Annex V point e)
-of the [European Digital Identity Regulation] SHALL be included (see ARB_18 in [Topic 12]).
-* One or more attributes or metadata representing the location meant in Annex V point h)
-of the [European Digital Identity Regulation] SHALL be included. This location SHALL
-indicate at least the URL at which a machine-readable version of the trust anchor to be
-used for verifying the QEAA can be found or looked up (see ARB_20 in [Topic 12]).
-
-**Requirements for PuB-EAA**
-
-* An attribute as meant in  Annex VII point a) of the [European Digital Identity Regulation]
-SHALL be included (see ARB_11 in [Topic 12]). See also section 2.1.
-* One or more attributes or metadata representing the set of data meant in Annex
- VII point b) of the [European Digital Identity Regulation] SHALL be included (see ARB_14 in [Topic 12]).
-* One or more attributes representing the set of data meant in Annex VII point c)
-of the [European Digital Identity Regulation] SHALL be included (see ARB_16 in [Topic 12]).
-* One or more attributes or metadata representing the set of data meant in Annex VII point e)
-of the [European Digital Identity Regulation] SHALL be included (see ARB_18 in [Topic 12]).
-* one or more attributes or metadata representing the location meant in Annex VII point h)
-of the [European Digital Identity Regulation] SHALL be included. This location SHALL
-indicate at least the URL at which a machine-readable version of the qualified
-certificate that signed the PuB-EAA can be found or looked up. (see ARB_20 in [Topic 12])
-
-**Requirements for non-qualified EAA**
-
-* An attribute indicating that the attestation is an EAA should be included (see ARB_12 in [Topic 12]).
-See also section 2.1.
-* One or more attributes or metadata representing the set of data meant in Annex
-V point b) of the [European Digital Identity Regulation] SHALL be included (see ARB_15 in [Topic 12]).
-* One or more attributes representing the set of data meant in Annex V point c) of the
-[European Digital Identity Regulation] SHOULD be included (see ARB_17 in [Topic 12])
-* One or more attributes representing the set of data meant in Annex V point e) of
-the [European Digital Identity Regulation] SHOULD be defined (see ARB_19 in [Topic 12]).
-* One or more attributes or metadata representing the location at which a machine-readable
-version of the trust anchor to be used for verifying the EAA can be found or
-looked up SHOULD be defined. What this location indicates precisely is dependent
-on the nature of the mechanism used for distributing trust anchors, detailed in section
-5 (see ARB_21 in [Topic 12])
-
 ### 2.1 Introduction
 
-*In this section, briefly introduce the overall design and purpose of the specific attestation type
-defined by this Rulebook, including key decisions regarding its attributes and
-legal categorization.*
+SCA-Card (DPC) is a simple attestation type with only top-level attributes, all of which are selectively
+disclosable. The attestation payload is intentionally minimal: it identifies the credential instance, the
+payment network, and optionally the digitised card through an opaque token reference. It never contains
+the PAN, the card BIN, or the last four digits; those are display-only data carried in the unsigned
+display meta-data object described in Section 2.9.
 
-*According to Annex V point a) and  Annex VII point a) of the [European Digital Identity Regulation]
-an indication, at least in a form suitable for automated processing, that the attestation
-has been issued as a QEAA or Pub-EAA SHALL be defined. Similarly, according to ARB_12
-of [Topic 12] of Annex 2 of the ARF a similar indication SHOULD be defined for non-qualified EAA.
+Unlike the other attestations of the WE BUILD SCA family, SCA-Card (DPC) does not define a `sub` claim.
+The EMVCo source model has no subject identifier; the `credential_id` attribute identifies the credential
+instance and plays that role.
 
-This document defines the attribute "attestation_legal_category" which SHALL have
-the value "QEAA" or "PuB-EAA" or "non-qualified-EAA".*
+Co-badged cards, cards that participate in more than one payment network, are out of scope for the
+WE BUILD profile of this attestation: WE BUILD supports SCA-Card (DPC) for single-network cards only,
+and each attestation identifies exactly one payment network. The EMVCo source specification [EMV-DPC]
+defines a per-badge credential model for co-badged cards; that model MAY be adopted in a future version
+of this Rulebook.
 
-*For complex attestations, authors SHOULD include or reference a logical model, diagram, or similar
-representation that explains the main entities, relationships, and attribute groupings. Such models
-may often be reused from an existing attestation description or use-case documentation.*
-
-> Example
->
-> The attestation description for Use Case X already contains a domain model showing the holder,
-> issuer, project, permit, and validity period. That model may be copied here and adjusted so that
-> the terminology exactly matches the rulebook.
-
-*In the following subsections 2.2 - 2.7 define in an encoding independent manner all
-mandatory, optional, and conditional attributes and metadata. In each subsection
-provide a table of the following form. When applicable, use Sections 2.8 and 2.9 to document
-code lists and integrity rules that are needed to interpret these attributes consistently:*
-
-*Where available, authors SHOULD include a stable semantic term reference (for example a URI,
-IRI, or controlled identifier from an agreed semantics catalogue) for each attribute or metadata item.*
-
-| **Data Identifier** | **Semantic Reference** | **Definition** | **Data type** | **Example value** |
-|------------------------|--------------------------|--------------|--------------|--------------|
-| *Provide a unique attribute identifier* | *Provide a stable semantics term reference* | *Briefly describe the semantic of this attribute* | *Provide a type, e.g., integer, string, boolean, date.* | *Give an example value* |
-
-*NOTE Data identifiers should be unambiguous, machine-readable where possible, and
-avoid natural-language ambiguities.*
+This document defines the attribute `attestation_legal_category` which SHALL have the value
+`"non-qualified-EAA"`.
 
 ### 2.2 Mandatory attributes
 
 | **Data Identifier** | **Semantic Reference** | **Definition** | **Data type** | **Example value** |
-|------------------------|--------------------------|--------------|--------------|--------------|
-| *Provide a value* | *Provide a value or N/A* | *Provide succinct text* | *Provide a value* | *Provide a value* |
+|---|---|---|---|---|
+| credential_id | N/A | Unique identifier of this specific credential instance. The value is issuer-specific and must uniquely identify the credential within the issuer's namespace. It SHOULD be generated using a collision-resistant mechanism (e.g., UUID). The `credential_id` identifies the credential artefact itself rather than the underlying payment card. | string | urn:uuid:9f2b7a2e-3b74-4a0d-9b1a-0e6a91f5d2c8 |
+| network | N/A | Payment network or scheme associated with the credential, as a single string value. Each attestation is issued for exactly one network. Co-badged cards are out of scope; see Section 2.1. | string | mastercard |
 
 ### 2.3 Optional attributes
 
 | **Data Identifier** | **Semantic Reference** | **Definition** | **Data type** | **Example value** |
-|------------------------|--------------------------|--------------|--------------|--------------|
-| *Provide a value* | *Provide a value or N/A* | *Provide succinct text* | *Provide a value* | *Provide a value* |
+|---|---|---|---|---|
+| card_id | N/A | Opaque identifier of the digitised payment instrument for which this attestation is issued, specific to this attestation's network, typically the token or card reference provisioned by that network's token service provider. The value is issuer-specific and MUST NOT reveal sensitive card data such as the full PAN. | string | mc-8c3f2d1a |
 
-### 2.4 Conditional attributes
-
-| **Data Identifier** | **Semantic Reference** | **Definition** | **Data type** | **Example value** |
-|------------------------|--------------------------|--------------|--------------|--------------|
-| *Provide a value* | *Provide a value or N/A* | *Provide succinct text* | *Provide a value* | *Provide a value* |
-
-### 2.5 Mandatory metadata
+### 2.4 Mandatory metadata
 
 | **Data Identifier** | **Semantic Reference** | **Definition** | **Data type** | **Example value** |
-|------------------------|--------------------------|--------------|--------------|--------------|
-| *Provide a value* | *Provide a value or N/A* | *Provide succinct text* | *Provide a value* | *Provide a value* |
+|---|---|---|---|---|
+| iss | https://www.rfc-editor.org/info/rfc7519/#section-4.1.1 | Issuer URL identifying the attestation provider | string (URI) | https://issuer.bank.example |
+| iat | https://www.rfc-editor.org/info/rfc7519/#section-4.1.6 | Unix timestamp designating the time when the attestation was issued | integer (Long) | 1772195095 |
+| exp | https://www.rfc-editor.org/info/rfc7519/#section-4.1.4 | Unix timestamp denoting the technical validity expiration of the attestation | integer (Long) | 1835267095 |
+| vct | Section 3.2.1 of [SD-JWT VC] | Denotes type of attestation; SHALL be an issuer-specific URL extending the WE BUILD base VCT | string (URI) | https://issuer.bank.example/credentials/sca/card-dpc/1.0 |
+| cnf | https://www.rfc-editor.org/info/rfc7800 | Object containing the JWK of the holder's public key (device binding). Each credential instance SHALL have its own unique holder binding key pair; see Section 2.7. | JSON Object | `{"jwk": {"kty":"EC","crv":"P-256",...}}` |
 
-### 2.6 Optional metadata
-
-| **Data Identifier** | **Semantic Reference** | **Definition** | **Data type** | **Example value** |
-|------------------------|--------------------------|--------------|--------------|--------------|
-| *Provide a value* | *Provide a value or N/A* | *Provide succinct text* | *Provide a value* | *Provide a value* |
-
-### 2.7 Conditional metadata
+### 2.5 Conditional metadata
 
 | **Data Identifier** | **Semantic Reference** | **Definition** | **Data type** | **Example value** |
-|------------------------|--------------------------|--------------|--------------|--------------|
-| *Provide a value* | *Provide a value or N/A* | *Provide succinct text* | *Provide a value* | *Provide a value* |
+|---|---|---|---|---|
+| nbf | https://www.rfc-editor.org/info/rfc7519/#section-4.1.5 | Unix timestamp denoting the first time the attestation may be used. Conditionally mandatory when `nbf` and `iat` differ. | integer (Long) | 1772195095 |
 
-### 2.8 Code lists
-
-*Use this section for controlled vocabularies, enumerations, value sets, or external catalogues
-that are necessary to interpret one or more attributes or metadata items. Definitions may be reused
-from the attestation description or other use-case documentation and refined here where needed.*
-
-*For each code list, authors SHOULD state the field to which it applies, the allowed values, their
-meaning, the source vocabulary or reference, and any extensibility rule or governance note.*
+### 2.6 Code lists
 
 | **Field name** | **Allowed values** | **Meaning** | **Source / vocabulary** | **Notes / extensibility** |
 |----------------|--------------------|-------------|--------------------------|---------------------------|
-| *Provide a field name* | *List the allowed values* | *Explain what each value means* | *Reference the source* | *State whether extensions are allowed* |
+| `network` | Open list of lower-case payment network identifiers, e.g. `mastercard`, `maestro`, `visa` | Identifies the payment network that can route a transaction for this attestation | [EMV-DPC] logical credential model | New values MAY be introduced when they are used consistently across issuer, Wallet, and verifier implementations. The value SHALL equal the `network_branding.network` value in the accompanying display meta-data (see Section 2.7, IR-04). |
 
-> Example
->
-> | **Field name** | **Allowed values** | **Meaning** | **Source / vocabulary** | **Notes / extensibility** |
-> |----------------|--------------------|-------------|--------------------------|---------------------------|
-> | `signatory_rule` | `sole`, `joint` | Indicates whether the representative may bind the organisation alone or only together with one or more additional representatives | EUCC attestation description / WE BUILD company representation model | Additional values SHOULD only be introduced if they are defined consistently across issuer and verifier implementations |
-
-### 2.9 Integrity rules
-
-*Use this section to define integrity or consistency rules that are not fully captured by the
-encoding format or schema alone, such as cross-field dependencies, temporal consistency checks,
-mutual exclusivity, or conditional combinations of values.*
-
-*Integrity rules may be copied and refined from an attestation description, logical model, or
-business-rule specification where available.*
+### 2.7 Integrity rules
 
 | **Rule ID** | **Rule statement** | **Why it exists** | **Where enforced** | **Verifier / issuer behavior on failure** |
-|-------------|--------------------|-------------------|--------------------|-------------------------------------------|
-| *Provide a rule identifier* | *State the rule precisely* | *Explain the rationale* | *Issuer, verifier, schema validation, or business process* | *Describe rejection, warning, or remediation behavior* |
+|---|---|---|---|---|
+| IR-01 | `card_id` MUST NOT reveal sensitive card data such as the full PAN or fragments of it | Data minimisation; prevents exposure of card data to verifiers and intermediaries | Issuer | Issuer SHALL NOT issue the attestation; a Verifier detecting PAN data SHOULD reject the presentation and report the issuer |
+| IR-02 | `network` SHALL be single-valued; the attestation SHALL identify exactly one payment network | Gives DCQL native value matching and makes the network-to-token association unambiguous | Issuer, schema validation | Issuer fails to issue the attestation |
+| IR-03 | Each credential instance SHALL have its own unique holder binding key pair; keys SHALL NOT be shared across credential instances | Prevents a verifier from correlating attestations of the same holder or card through a shared public key | Issuer, Wallet | Wallet SHALL reject a credential whose binding key it has seen in another credential |
+| IR-04 | `network_branding.network` in the display meta-data SHALL equal the `network` claim of the attestation it accompanies | Keeps the rendered network branding consistent with the signed claim | Issuer, Wallet | Wallet SHALL treat the display meta-data as invalid and fall back to the `network` claim value |
 
-> Example
->
-> | **Rule ID** | **Rule statement** | **Why it exists** | **Where enforced** | **Verifier / issuer behavior on failure** |
-> |-------------|--------------------|-------------------|--------------------|-------------------------------------------|
-> | `IR-01` | If `legal_representative.natural_person` is present, `full_name` and `date_of_birth` SHALL be present. If `legal_representative.legal_person` is present, `name`, `id`, and `legal_form_type` SHALL be present. | Prevents incomplete representation statements and ensures that a relying party can determine whether the representative is a natural person or a legal person and validate the representation data accordingly. | Issuer business rules, schema validation, and verifier business validation. | Issuer SHALL reject incomplete representative data; verifier SHALL treat the representation information as invalid or insufficient for the transaction. |
+### 2.8 VCT rules
+
+For SCA-Card (DPC) the proposed base VCT is: `https://webuildconsortium.eu/sca/sca-card-dpc/1.0`
+
+This base type has claims `"extends"` and `"extends#integrity"` that point to the base SCA VCT type
+`https://webuildconsortium.eu/sca/1.0`.
+
+Actual SCA-Card (DPC) attestations issued by a credential issuer carry an issuer-specific VCT URL such
+as `https://issuer.bank.example/credentials/sca/card-dpc/1.0` and their metadata contains claims
+`"extends"` and `"extends#integrity"` pointing to the base SCA-Card (DPC) type
+`https://webuildconsortium.eu/sca/sca-card-dpc/1.0`.
+
+Versioning of VCT types SHALL follow an `x.y` version model where:
+- `x` is the major version - introduces breaking changes (removing claims from metadata, renaming or
+  repurposing claims in transaction data).
+- `y` is the minor version - introduces backward-compatible changes (adding elements, adding display claims,
+  adding languages).
+
+With this mechanism, integrity checks remain in place and the need for re-issuance of credentials across all
+wallets is minimised.
+
+The attribute set and semantics of this attestation type are derived from the EMVCo Digital Payment
+Credential type `com.emvco.dpc.card` defined in [EMV-DPC]. Within the WE BUILD pilot, the WE BUILD VCT
+hierarchy above is used as the type identifier; the EMVCo identifier is referenced for semantic alignment
+only.
+
+### 2.9 Display meta-data
+
+Each SCA-Card (DPC) attestation is delivered together with an unsigned display meta-data object that
+defines how the Wallet presents the card to the User, both in the card representation in the Wallet and
+on the payment sheet. Providing this data with the attestation enables consistent, issuer-controlled
+rendering without reliance on out-of-band branding repositories. The object carries the following fields
+within its top-level `card` object:
+
+| **Field** | **Meaning** | **Display intent** |
+|---|---|---|
+| `type` | Card product type: code `CREDIT`, `DEBIT`, or `PREPAID`, with an optional human-readable label | Product-type caption; the label MAY be localised |
+| `last_four` | Last four digits of the PAN | User recognition of the card in Wallet and checkout interfaces; display-only, never a verifiable claim |
+| `alias` | User-facing card name (e.g. "Platinum Credit Card") | Primary card title; MAY be localised |
+| `card_art` | Card artwork images with `DEFAULT`, `LIGHT`, and `DARK` theme variants | Card visual in the Wallet and on the payment sheet |
+| `issuer` | Issuer branding (name, logo) with optional country, website, and support contacts | Issuer identity and customer-support entry points |
+| `co_branding` | Optional co-brand partner branding (e.g. airline or retailer) | Secondary brand rendered alongside the card |
+| `network_branding` | Name and logo of this attestation's network; exactly one per attestation | Network logo on the card visual |
+
+Image resources referenced by `image_url` attributes MAY be provided either as externally hosted HTTPS
+URLs or as embedded Data URLs as defined in [RFC 2397]. Image arrays SHALL contain at least one image;
+when only a single image is provided, its `theme` value SHALL be `DEFAULT`, indicating that the image is
+suitable for any UI theme.
+
+The display meta-data object:
+
+* is NOT part of the signed attestation and carries no issuer signature;
+* is transported in the `display` array of the OpenID4VCI credential response, enabling the Wallet to
+  render the issued attestation with full visual fidelity, and MAY additionally be provided in the
+  credential offer, enabling the User to recognise the card and give informed consent before issuance;
+* is never presented to a Verifier. This is guaranteed structurally: the object is not a claim in the
+  signed credential and display meta-data is not part of an OpenID4VP presentation.
+
+Wallet behaviour for rendering this data is specified in Chapter 4 (Wallet display handling).
+
+The table above defines field semantics only; the authoritative definition of the object's structure
+(data types, patterns, enumerations, and required fields) is the machine-readable JSON Schema published
+in this catalogue at
+[`data-schemas/display/sca-card-dpc-display-meta.schema.json`](../../data-schemas/display/sca-card-dpc-display-meta.schema.json),
+with a sample at
+[`data-schemas/display/sample-data/sca-card-dpc-display-meta-sample.json`](../../data-schemas/display/sample-data/sca-card-dpc-display-meta-sample.json).
 
 # 3 Attestation encoding
 
 ## 3.1 ISO/IEC 18013-5-compliant encoding
 
-*If the attestation type supports the the format specified in ISO/IEC 18013-5,
-then in this section the  ISO/IEC 18013-5-compliant encoding of attributes and metadata
-should be defined.*
+This encoding is not supported for this attestation type. SCA-Card (DPC) SHALL be issued exclusively in
+the SD-JWT VC format specified in Section 3.2. Presentation when the Wallet Unit and the Relying Party
+are in proximity without using the internet is not required for this attestation type (see ARB_02 in
+[Topic 12]): all supported use cases are online remote-commerce flows.
 
-*It is noted that (see ARB_02 in [Topic 12]) the Schema Provider SHALL analyse whether it must
-be possible for a User to present that type of attestation when the Wallet Unit
-and the Relying Party are in proximity and attestations are presented without
-using the internet. If so,the attestations must be issued in the ISO/IEC 18013-5-compliant
-mdoc format.*
+## 3.2 SD-JWT VC-based encoding
 
-*Furthermore, in this section a document type SHALL be defined, which SHALL be
-unique within the scope of the EUDI Wallet ecosystem (see ARB_05 in [Topic 12]).*
+The SCA-Card (DPC) attestation supports the SD-JWT VC format as specified in [SD-JWT VC], compliant with
+the [HAIP] profile.
 
-[RULEBOOK AUTHOR TO DEFINE THE ATTESTATION TYPE]
+**VCT (Verifiable Credential Type):** `https://issuer.bank.example/credentials/sca/card-dpc/1.0`
+(issuer-specific; MUST extend `https://webuildconsortium.eu/sca/sca-card-dpc/1.0` via `"extends"` and
+`"extends#integrity"` claims in VCT metadata)
 
-*Provide a list of available encoding formats and their specifications (e.g., encoding, maximum lengths,
-date formats, etc). For example:*
+The machine-readable JSON Schema of the resolved claim set is published in this catalogue at
+[`data-schemas/sd-jwt/sca-card-dpc-sd-jwt.json`](../../data-schemas/sd-jwt/sca-card-dpc-sd-jwt.json),
+with a sample at
+[`data-schemas/sd-jwt/sample-data/sca-card-dpc-sd-jwt-sample.json`](../../data-schemas/sd-jwt/sample-data/sca-card-dpc-sd-jwt-sample.json).
 
-* tstr, uint, bstr, bool and tdate are CDDL representation types defined in
-  [RFC 8610].
-    * Regarding type tstr: this document confirms that, as specified in [RFC
-    8949], a tstr SHALL be encoded in UTF-8 and SHALL support the full Unicode
-    range.
-    * All attributes having encoding type tstr SHALL have a maximum length of
-    150 characters.
-    * This document specifies full-date as full-date = #6.1004(tstr), where tag
-    1004 is specified in [RFC 8943].
-    * In accordance with [RFC 8949], section 3.4.1, a tdate attribute SHALL
-    contain a date-time string as specified in [RFC 3339]. In accordance with
-    [RFC 8943], a full-date attribute SHALL contain a full-date string as
-    specified in [RFC 3339].
-    * The following requirements apply to the representation of dates in
-    attributes, unless otherwise indicated:
-        * Fractions of seconds SHALL NOT be used;
-        * A local offset from UTC SHALL NOT be used; the time-offset defined in
-        [RFC 3339] SHALL be to "Z".
-    * [RFC 8949], section 4.2, describes four rules for canonical CBOR. Three of
-    those rules SHALL be implemented for all CBOR structures, as
-    follows:
-        * integers (major types 0 and 1) SHALL be as small as possible;
-        * the expression of the length in a bstr, tstr, array or map SHALL be as
-        short as possible;
-        * indefinite-length items SHALL be made into definite-length items.
+**IANA-registered JWT claims (not selectively disclosable):**
 
-*This section should include a table the data identifier specified in
-Chapter 2,  the corresponding attribute identifier to be used in
-presentation requests and responses according to [ISO/IEC 18013-5] and the encoding
-of each attribute.*
+| **Data Identifier** | **Attribute identifier** | **Encoding format** | **Reference/Notes** | **Disclosable** |
+|---|---|---|---|---|
+| iss | iss | string (URI) | [RFC 7519] §4.1.1 | MUST NOT |
+| iat | iat | integer (NumericDate) | [RFC 7519] §4.1.6 | MUST NOT |
+| exp | exp | integer (NumericDate) | [RFC 7519] §4.1.4 | MUST NOT |
+| nbf | nbf | integer (NumericDate) | [RFC 7519] §4.1.5 - conditionally mandatory when `nbf` differs from `iat` | MUST NOT |
 
-*Additionally, the following rules should be followed:*
+**Private claim names and SD-JWT-specific claims:**
 
-* When specifying new attributes, existing conventions
-for attribute identifier values and attribute syntaxes SHOULD
-be considered (see ARB_07 in [Topic 12]).
-* Each attribute SHALL be defined within an attribute namespace.
-    * An attribute namespace
-SHALL fully define the identifier, the syntax, and the semantics of each attribute
-within that namespace.
-    * An attribute namespace SHALL have an identifier that is
-unique within the scope of the EUDI Wallet ecosystem, and each attribute
-identifier SHALL be unique within that namespace (see ARB_06a in [Topic 12])
-    * A domestic namespace MAY defined
-to specify attributes that are specific to this Rulebook and are not included in
-the applicable EU-wide or sectoral namespace (see ARB_10 in [Topic 12]).
+| **Data Identifier** | **Attribute identifier** | **Encoding format** | **Notes** | **Disclosable** |
+|---|---|---|---|---|
+| vct | vct | string (URI) | Denotes attestation type; SHALL be an issuer-specific URL extending the WE BUILD base VCT | MUST NOT |
+| cnf | cnf | JSON Object | JWK of holder's public key (device binding); see [RFC 7800]. Unique per credential instance (IR-03). | MUST NOT |
+| attestation_legal_category | attestation_legal_category | string | SHALL be `"non-qualified-EAA"` | MUST NOT |
+| credential_id | credential_id | string | Unique identifier of the credential instance | MUST |
+| network | network | string | Single payment network identifier | MUST |
+| card_id | card_id | string | Opaque per-network token reference; MUST NOT reveal PAN data | MUST |
 
-| **Data Identifier** | **Attribute identifier** | **Encoding format** | **Namespace**|
-|------------------------|--------------|------------------|------------------|
-| family_name | family_name | tstr | com.example.att.1|
+**Example JWT claim set (provider-side, before issuing SD-JWT):**
 
-*The corresponding entry for the "attestation_legal_category" attribute defined
-in Section 2.1 SHALL be:*
+```json
+{
+  "vct": "https://issuer.bank.example/credentials/sca/card-dpc/1.0",
+  "vct#integrity": "sha256-Cp5VgPMqzU7cphGIL0aRy54scWhTiBFB1FJYDLyO94w=",
+  "extends": "https://webuildconsortium.eu/sca/sca-card-dpc/1.0",
+  "extends#integrity": "sha256-gV1X+E7n79QEHEt9AI0VY3ZbNefHhZloJhpaHoYFqKM=",
+  "iss": "https://issuer.bank.example",
+  "iat": 1772195095,
+  "exp": 1835267095,
+  "cnf": {
+    "jwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "f83OJ3D2xF4wK2Yp6tK2vNhbbX6YsJhBKt3vnDnNQfQ",
+      "y": "x_FEzRu9w4J6v7P3cu6UytzszbmWzxubUANe0yoyl9A"
+    }
+  },
+  "attestation_legal_category": "non-qualified-EAA",
+  "_sd_alg": "sha-256",
+  "_sd": [
+    "X9yH4uRPd0rFgCnMq7LwKp3jZoStViEa2bDNcOIkT8s",
+    "mBpQ1vYeKrDnCjHaWgFxZ5tSoUilNcT3LdR7yEhAP94",
+    "kL8nJpFaOcQrBdVwXgY2eIhCmT5ZsU1RoPN6yDK7WHv"
+  ]
+}
+```
 
-| **Data Identifier** | **Attribute identifier** | **Encoding format** |**Namespace**|
-|------------------------|--------------|------------------|------------------|
-| attestation_legal_category | attestation_legal_category | tstr |com.example.att.1|
+**Example issued SD-JWT (compact serialization, abbreviated):**
 
-Finally, illustrative examples SHALL be included.
+```
+eyJhbGciOiJFUzI1NiIsInR5cCI6ImRjK3NkLWp3dCIsImtpZCI6Imlzc3Vlci1rZXktMSJ9
+.
+eyJpc3MiOiJodHRwczovL2lzc3Vlci5iYW5rLmV4YW1wbGUiLCJpYXQiOjE3NzIxOTUwOTUs
+ImV4cCI6MTgzNTI2NzA5NSwidmN0IjoiaHR0cHM6Ly9pc3N1ZXIuYmFuay5leGFtcGxlL2Ny
+ZWRlbnRpYWxzL3NjYS9jYXJkLWRwYy8xLjAiLCJjbmYiOnsiandrIjp7Imt0eSI6IkVDIn19
+LCJhdHRlc3RhdGlvbl9sZWdhbF9jYXRlZ29yeSI6Im5vbi1xdWFsaWZpZWQtRUFBIiwiX3Nk
+X2FsZyI6InNoYS0yNTYiLCJfc2QiOlsiLi4uIl19
+.
+<issuer-signature>
+~WyI8c2FsdC0xPiIsImNyZWRlbnRpYWxfaWQiLCJ1cm46dXVpZDo5ZjJiN2EyZS0uLi4iXQ
+~WyI8c2FsdC0yPiIsIm5ldHdvcmsiLCJtYXN0ZXJjYXJkIl0
+~WyI8c2FsdC0zPiIsImNhcmRfaWQiLCJtYy04YzNmMmQxYSJd
+```
 
-[RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF FULL OR PARTIAL mDOC OF THE ATTESTATION]
+**Human-readable SD-JWT payload and disclosure descriptions:**
 
-[RULEBOOK AUTHOR TO PROVIDE THE ATTRIBUTES AND THEIR VALUES INCLUDED IN THE EXAMPLE]
+Non-selectively-disclosable claims (always present in the JWT body):
 
-### 3.2 SD-JWT VC-based encoding
+| Claim | Value |
+|---|---|
+| `iss` | `https://issuer.bank.example` |
+| `iat` | `1772195095` (2026-02-27T12:24:55Z) |
+| `exp` | `1835267095` (2028-02-27T12:24:55Z) |
+| `vct` | `https://issuer.bank.example/credentials/sca/card-dpc/1.0` |
+| `cnf` | `{jwk: {kty: "EC", crv: "P-256", ...}}` |
+| `attestation_legal_category` | `non-qualified-EAA` |
 
-*If the attestation type supports the format specified in "SD-JWT-based Verifiable
-Credentials (SD-JWT VC)", then in this section the SD-JWT VC-compliant encoding
-of attributes and metadata SHALL be defined. It SHALL be ensured that the attestations
-comply with the 'SD-JWT VCs' profile specified in [HAIP] (see ARB_01b in [Topic 12]).*
+Selectively-disclosable claims (each disclosure encoded as `[<salt>, <claim_name>, <claim_value>]`
+base64url per [SD-JWT VC]):
 
-*It is noted that a Schema Provider MAY specify in the Attestation
-Rulebook that that type of attestation must be issued in the [SD-JWT VC]-compliant
-format, provided the [SD-JWT VC] specification has been approved by an EU standardisation
-body or by the European Digital Identity Cooperation Group established pursuant to
-Article 46e(1) of the [European Digital Identity Regulation] (see ARB_03 in [Topic 12]).*
+| Disclosure # | Claim | Value |
+|---|---|---|
+| ~0 | `credential_id` | `urn:uuid:9f2b7a2e-3b74-4a0d-9b1a-0e6a91f5d2c8` |
+| ~1 | `network` | `mastercard` |
+| ~2 | `card_id` | `mc-8c3f2d1a` |
 
-*In this section, a Verifiable Credential Type (`vct`) SHALL be defined,
-which SHALL be unique within the scope of the EUDI Wallet ecosystem (see ARB_05 in [Topic 12]).*
+## 3.3 W3C Verifiable Credentials Data Model-based encoding
 
-[RULEBOOK AUTHOR TO DEFINE THE ATTESTATION TYPE]
-
-*Additionally, when specifying new attributes, existing conventions
-for attribute identifier values and attribute syntaxes SHOULD
-be considered (see ARB_07 in [Topic 12]).*
-
-*Rulebook authors SHALL ensure that each claim name is either
-
-* included in the IANA registry for JWT claims,
-* is a Public Name as defined in [RFC 7519], or
-* or is a Private Name specific to the attestation type. (see ARB_06b in [Topic 12]).*
-
-*For all claims (i.e., all top-level properties, all nested properties, and all array entries),
-the Rulebook SHALL specify whether an Attestation Provider MUST, MAY, or MUST NOT make that
-claim selectively disclosable (see ARB_30 in [Topic 12]).*
-
-*Rulebook authors SHOULD consider defining a Type Metadata Document for the attestation type
-specified in the Rulebook, as defined in Chapter 6 of [SD-JWT VC]. If such a document is defined,
-it SHOULD contain the Claim Selective Disclosure Metadata (defined in Section 9.3 of [SD-JWT VC])
-for each of the claims, in order to specify if that claim is selectively disclosable (see ARB_31
-in [Topic 12]).*
-
-*IANA-registered claims should be presented in table that
-includes their data identifier, attribute identifier,
-encoding format, and reference or note. For example,*
-
-| **Data Identifier** | **Attribute identifier** | **Encoding format** |**Reference/Notes** |**Disclosable**|
-|-------------------- |--------------------------|---------------------|--------------------|---------------|
-| family_name | family_name | string | Section 5.1 of [OIDC] | MUST |
-
-*A similar table should be used for Public Names and for Private Names specific
-to the attestation type defined in this document. For
-example:*
-
-| **Data Identifier** | **Attribute identifier** | **Encoding format** | **Notes** |**Disclosable**|
-|---------------------|--------------------------|---------------------|-----------|---------------|
-| trust_anchor | trust_anchor | string | The trust anchor defined in Section 5 | MUST NOT |
-
-*The corresponding entry for the "attestation_legal_category" attribute defined
-in Section 2.1 SHALL be:*
-
-| **Data Identifier** | **Attribute identifier** | **Encoding format** | **Notes** |**Disclosable**|
-|---------------------|--------------------------|---------------------|-----------|---------------|
-| attestation_legal_category | attestation_legal_category | string | Defined in Attestation Rulebook template |MUST NOT|
-
-Finally, illustrative examples SHALL be included.
-
-[RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF THE JWT CLAIM SET USED BY THE PROVIDER]
-
-[RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF THE ISSUED SD-JWT (IN base64 ENCODING)]
-
-[RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF A HUMAN READABLE VERSION OF THE SD-JWT PAYLOAD
-AND A DESCRIPTION OF THE DISCLOSURES INCLUDED IN THE EXAMPLE]
-
-### 3.3 W3C Verifiable Credentials Data Model-based encoding
-
-*If the attestation type supports the the format specified in W3C Verifiable Credentials
-Data Model, then in this section the  corresponding encoding  of attributes and
-metadata should be defined.*
-
-*It is noted that only a a non-qualified EAA can use this format (see ARB_01a in [Topic 12])*
-
-*Tables similar to the ones specified in section 4 SHALL be defined.*
-
-*This section SHALL reference one or more documents specifying in detail how a
-Relying Party can request attributes from a such an attestation, and how a User
-can selectively disclose attributes from such an attestation. Moreover, these
-referenced documents SHALL be approved by an EU standardisation body or by the European
-Digital Identity Cooperation Group established pursuant to Article 46e(1) of the
-[European Digital Identity Regulation] (see ARB_04 in [Topic 12]).*
-
-*Finally, illustrative examples SHALL be included.*
-
-[RULEBOOK AUTHOR TO PROVIDE HUMAN READABLE EXAMPLE OF THE ISSUED ATTESTATION]
-
-[RULEBOOK AUTHOR TO PROVIDE AN EXAMPLE OF THE PROOF TYPE]
+This encoding is not supported for this attestation type. The attestation SHALL be issued exclusively
+in the SD-JWT VC format.
 
 ## 4 Attestation usage
 
-*Briefly describe the primary use cases or scenarios for which this attestation
-type is intended*
+SCA-Card (DPC) is designed for the 3-party model in remote commerce: the credential issuer and the
+verifier are in different organisations. The verifying side is typically a merchant, PSP, or a payment
+system component acting on their behalf. Integration of DPC presentations into payment system rails,
+for example EMVCo Secure Remote Commerce (Click to Pay), is defined by the respective payment system
+specifications and is out of scope of this Rulebook.
 
-*Additionally, in this section it SHOULD  be specified whether a Relying Party receiving the attestation
-must request and verify a PID (see ARB_27 in [Topic 12]). Also beyond PID verification,
-it SHOULD be defined what other key obligations does a Relying Party have when processing
-this attestation type (e.g., signature verification, freshness checks)*
+**Primary use cases:**
 
-*Furthermore, provide potential presentation requirements, e.g., are there specific
-requirements for how this attestation must be presented (e.g., online, offline, specific protocols)?"*
+1. **Payment authentication with a known credential:** The verifier already holds a reference to the
+   digitised card (e.g. token on file or recognised returning consumer) and requests a presentation of
+   the specific attestation, typically by `credential_id`.
+2. **Authenticated guest checkout with credential discovery:** The verifier does not know the card. The
+   presentation request filters by supported networks, the User selects a card in the Wallet, and the
+   disclosed `card_id` gives the verifier the network token reference needed to route the transaction.
 
-*Specify whether an attestation of this type SHALL or SHOULD be device-bound or non-device-bound, see ARB_34 in [Topic 12]*
+Both use cases provide multi-factor authentication through device biometrics or PIN plus the
+device-bound key, supporting PSD2 Strong Customer Authentication. SCA-Card (DPC) is exclusively used in
+presentation scenarios where transaction data is present in the presentation request.
 
-*If an attestation of this type is device-bound, specify if it SHALL, SHOULD or MAY be cryptographically bound to another type of attestation on the same Wallet Unit. If needed (based on this decision), include the attribute `cryptographically_bound_to` defined in ARB_28 as an optional, recommended, or mandatory attribure in [Section 2.5](#26-optional-metadata). If present in an Attestation Rulebook, the identifier for this attribute SHALL be "cryptographically_bound_to" for both ISO/IEC 18013-5 and SD-JWT VC-compliant attestations, and its contents SHALL be a `tstr` or `string` (as applicable) containing an attestation type or vct (see ARB_05). Finally, specify the value of the `tstr` or `string`.* 
+**Relying Party obligations:**
 
-*EXAMPLE   In case an attestation type of this type must be bound to a PID, the value of the `tstr` or `string` must be set to "eu.europa.ec.eudi.pid.1" or "urn:eudi:pid:1". Note that it does not matter whether the attestation type or the vct value is used.*
+* The Relying Party SHALL verify the issuer signature and the `cnf` key binding (KB-JWT) before
+  accepting the attestation.
+* The Relying Party SHALL verify that presented transaction data is bound to the attestation as
+  specified in [Topic 20] and [TS12] ("sign what you see": the Wallet incorporates the payment details
+  shown to the User into the data signed by the device-bound key).
+* Verification of a PID alongside this attestation is not required.
 
-*Finally, in this section information about potential transactional data
-SHALL be defined; see [Topic 20] of Annex 2 of the ARF.*
+**Presentation requirements:**
+
+* SCA-Card (DPC) SHALL be presented online using OID4VP; presentation MAY be invoked through the W3C
+  Digital Credentials API.
+* Transaction data MUST be present in all presentation requests (see [Topic 20]).
+* The Wallet SHOULD respect VC metadata published by the Issuer at the VCT metadata endpoint.
+
+**Wallet requirements (normative):**
+
+* The Wallet SHALL present each matched attestation as a single card on the payment sheet.
+* The Wallet SHALL return exactly one attestation, the selected card's, as the response to the
+  credential query, with the key binding mechanism binding it to the transaction data.
+
+**Wallet display handling (normative):**
+
+* The Wallet SHOULD render the card in the Wallet UI and on the payment sheet using the display
+  meta-data delivered at issuance (Section 2.9), without relying on out-of-band branding repositories.
+* For themed images (`card_art` and branding logos), the Wallet SHOULD select the image variant matching
+  the active UI theme and SHALL fall back to the `DEFAULT` variant when no theme-specific image is
+  provided.
+* The Wallet SHALL support image resources provided as externally hosted HTTPS URLs as well as embedded
+  Data URLs per [RFC 2397].
+* When retrieving externally hosted images, the Wallet SHOULD take measures to prevent unintended
+  disclosure of User information, for example by avoiding transmission of identifying headers or by
+  using privacy-preserving fetch mechanisms.
+
+**Device binding:**
+
+* This attestation SHALL be device-bound (ARB_34 in [Topic 12]).
+* The device binding key SHALL be attested at AVA_VAN.4 or higher.
+* Each credential instance SHALL have its own unique binding key pair (IR-03).
+* The attestation MAY be cryptographically bound to the holder's PID. If so, `cryptographically_bound_to`
+  SHALL carry the value `"urn:eudi:pid:1"`.
+  Note that such binding weakens the unlinkability property provided by per-instance keys and SHOULD be
+  avoided unless required by the deployment.
+
+### 4.1 Issuance lifecycle
+
+Issuer of SCA-Card (DPC) is - for the purpose of WE BUILD - the card issuer or an entity issuing
+credentials on its behalf (the Credential Issuer in [EMV-DPC] terms).
+
+Before issuance, the Issuer SHALL check Wallet eligibility:
+
+* Wallet provider is trusted for this purpose via a trust list.
+* Wallet Unit is in operational state with valid WUA/WIA and PID.
+* Wallet Unit has an eligible WSCD available at AVA_VAN.4 or higher.
+* The user identified by this Wallet Unit is the same user authenticated into the issuer's environment.
+
+When issuing the attestation, the Issuer SHALL:
+
+* Use a sender-constrained token (DPoP) to ensure that only the requesting Wallet may receive the issued
+  credential.
+* Ensure that the attestation is device-bound with sufficient secure storage (AVA_VAN.4 or higher).
+* Deliver the display meta-data object (Section 2.9) in the `display` array of the credential response,
+  and MAY additionally include it in the credential offer to support user recognition before issuance.
+
+After receiving the attestation, the Wallet SHOULD notify the Issuer of successful acceptance.
+
+### 4.2 Presentation lifecycle
+
+SCA-Card (DPC) SHOULD be presented when the presentation request comes from a verifier participating in
+a payment transaction, with payment transaction data attached as described in [TS12].
+
+The following DCQL examples illustrate the two selection patterns in an OpenID4VP request. A Wallet
+SHALL treat an attestation as matching a requested VCT value when its `vct` claim or any type in its
+`extends` chain equals that value.
+
+**Query by Credential ID** (known-card scenario): requests a specific attestation and disclosure of
+`credential_id` and `network`.
+
+```json
+{
+  "credentials": [
+    {
+      "id": "dpc",
+      "format": "dc+sd-jwt",
+      "meta": {
+        "vct_values": ["https://webuildconsortium.eu/sca/sca-card-dpc/1.0"]
+      },
+      "claims": [
+        { "path": ["credential_id"], "values": ["urn:uuid:9f2b7a2e-3b74-4a0d-9b1a-0e6a91f5d2c8"] },
+        { "path": ["network"] }
+      ]
+    }
+  ]
+}
+```
+
+**Query by supported network** (guest checkout): filters on the `network` claim. Because every
+attestation carries a single-valued `network` claim, this uses standard DCQL `values` semantics. The
+Wallet shows each matching card once; after the User selects a card, the Wallet presents exactly one
+attestation and discloses only the requested attributes.
+
+```json
+{
+  "credentials": [
+    {
+      "id": "dpc",
+      "format": "dc+sd-jwt",
+      "meta": {
+        "vct_values": ["https://webuildconsortium.eu/sca/sca-card-dpc/1.0"]
+      },
+      "claims": [
+        { "path": ["network"], "values": ["mastercard", "visa"] },
+        { "path": ["credential_id"] },
+        { "path": ["card_id"] }
+      ]
+    }
+  ]
+}
+```
 
 ## 5 Trust anchors
 
-*Mechanisms for the provision of a trust anchor that SHALL
-be used for the verification of an attestation SHALL be defined in this section.*
-
-*It is noted that the ARF specifies the following for QEAAs and Pub-EAAs:*
-
-> To do this for [...] QEAAs the Relying Party Instance uses a trust anchor of
-the Provider obtained from a Trusted List. Note that the PID Provider or QEAA
-Provider may use an intermediate signing certificate to sign the PID or
-attestation, and use the trust anchor to sign the signing certificate, instead
-of signing the PID or attestation directly with the trust anchor.
->
-> For PuB-EAAs, the Relying Party Instance verifies a PuB-EAA by first
-verifying the signature of the PuB-EAA Provider over the PuB-EAA, using the
-PuB-EAA Provider certificate issued by a QTSP. Subsequently, the Relying Party
-Instance verifies the signature over this certificate, using the corresponding
-trust anchor from the QTSP Trusted List. Note that both the PuB-EAA Provider
-and the QTSP may use an intermediate signing certificate. All other things
-being equal, the verification of a PuB-EAA will therefore involve one or more
-extra certificates, compared to the verification of a PID or QEAA.
-
-*For non-qualified EAA in this section it SHOULD  be defined (see ARB_26 in [Topic 12])
-how the attributes or metadata representing the location at which a machine-readable
-version of the trust anchor to be used for verifying the attestation can be found,
-specified in section 2, are used. This includes a detailed description about how
-a Relying Party can obtain the trust anchors, as well as a detailed description about
-how this trust anchor can be used for verifying that the provider is authorized
-to issue the attestation. Additionally, for non-qualified EAA Providers this section
-MAY include a description of mechanisms that can be used by a Wallet Unit for
-verifying that the provider is authorized to issue this type of attestation (see
-ISSU_34 in [Topic 10])*
+SCA-Card (DPC) is a non-qualified EAA. The trust anchor mechanism for this attestation type is **TBD**
+and will be defined in a future version of this Rulebook. This includes the mechanism through which
+Relying Parties obtain the trust anchor used to verify the attestation and the mechanism through which
+they establish that an Issuer is authorized to issue this attestation type, for example a
+sector-specific issuer accreditation scheme such as an EMVCo-operated issuer root programme discussed
+in [EMV-DPC]-related work.
 
 ## 6 Revocation
 
-(Refer to [Topic 7] of the ARF for a list of High-Level Requirements related to Revocation)
+SCA-Card (DPC) attestations are **long-lived** by definition: the attestation is provisioned once and
+remains valid for an extended period, typically aligned with the lifecycle of the underlying digitised
+card. The validity period is expressed through the `exp` metadata.
 
-*In this section information about the revocation mechanism used SHALL be defined.*
-
-*For PID, QEAA, or PuB-EAA it SHALL  be defined whether  only short-lived attestations
-will be used, having a validity period of 24 hours or less, such that revocation
-will never be necessary, or that the attestations are revocable.*
-
-*For revocable attestations it SHALL be defined which of the following methods must be implemented:*
-
-* Use an Attestation Status List mechanism included in a Technical Specification
-that will be specified by the Commission.
-* Use an Attestation Revocation List mechanism included in a Technical Specification
-that will be specified by the Commission.
+The revocation mechanism for this attestation type is **TBD** and will be defined in a future version
+of this Rulebook.
 
 ## 7 Compliance
 
-*In this section explicitly state how this specific rulebook complies with the
-general EUDI framework, ARF, and relevant regulations*
+This Rulebook is aligned with the following specifications:
 
-[RULEBOOK AUTHOR TO DEFINE]
+* **[European Digital Identity Regulation]** (Regulation (EU) 2024/1183) - This is a non-qualified EAA.
+  Attributes and metadata satisfy the requirements of Annex V points b), c), and e) as applicable
+  (ARB_15, ARB_17, ARB_19).
+* **ARF [Topic 12]** - All ARB_ requirements applicable to non-qualified EAA have been addressed:
+  ARB_01b, ARB_02, ARB_05, ARB_06, ARB_06a, ARB_06b, ARB_07, ARB_09, ARB_10, ARB_12, ARB_15, ARB_17,
+  ARB_19, ARB_21, ARB_26, ARB_27, ARB_30, ARB_31, ARB_34.
+* **ETSI TS 119 472-1** - The Rulebook structure and attestation lifecycle follow this standard.
+* **[TS12]** - Attribute definitions and transaction data processing align with TS12 published by the
+  European Commission.
+* **[EMV-DPC]** - The logical credential model, disclosable attribute set, and display meta-data model
+  are derived from the EMVCo Digital Payment Credential specification, adapted to WE BUILD
+  type identifiers and metadata claims as described in Section 2.8. The source specification's co-badged
+  card handling is out of scope for WE BUILD (see Section 2.1).
+* **[HAIP]** - The SD-JWT VC encoding complies with the OpenID4VC High Assurance Interoperability
+  Profile.
 
 ## 8 References
 
-| **Item Reference** | **Standard name/details**|
-|--------------------|---------------------------|
+| **Item Reference** | **Standard name/details** |
+|---|---|
+| [EMV-DPC] | EMV Digital Payment Credential Specification - Schema Framework, EMVCo, and its DPC Card Credential & Display Meta-Data schema. Draft under review; no public URL at the time of writing. |
 | [European Digital Identity Regulation] | [Regulation (EU) 2024/1183](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202401183) of the European Parliament and of the Council of 11 April 2024 amending Regulation (EU) No 910/2014 as regards establishing the European Digital Identity Framework |
 | [HAIP] | Yasuda, K. *et al,* OpenID4VC High Assurance Interoperability Profile, OpenId Foundation, Version draft-03 |
 | [IANA-JWT-Claims] | IANA JSON Web Token Claims Registry. Available: <https://www.iana.org/assignments/jwt/jwt.xhtml> |
-| [ISO/IEC 18013-5] |  ISO/IEC 18013-5, Personal identification --- ISO-compliant driving licence - Part 5: Mobile driving licence (mDL) application, First edition, 2021-09 |
-| [OIDC] | Sakimura, N. et al., "OpenID Connect Core 1.0", OpenID Foundation. Available: <https://openid.net/specs/openid-connect-core-1_0.html> |
-| [RFC 3339] | RFC 3339  - Date and Time on the Internet: Timestamps, G. Klyne et al., July 2002 |
-| [RFC 8610] | RFC 8610  - Concise Data Definition Language (CDDL): A Notational Convention to Express Concise Binary Object Representation (CBOR) and JSON Data Structures, H. Birkholz et al., June 2019 |
-| [RFC 8943] | RFC 8943  - Concise Binary Object Representation (CBOR) Tags for Date, M. Jones et al., November 2020 |
-| [RFC 8949] | RFC 8949 - Concise Binary Object Representation (CBOR), C. Bormann et al., December 2020 |
-| [SD-JWT VC] |  SD-JWT-based Verifiable Credentials (SD-JWT VC). Available: <https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/>, version draft-ietf-oauth-sd-jwt-vc-09  |
-| [Topic 7] | ARF Annex 2 - Topic 7 - Attestation revocation and revocation checking Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a237-topic-7-attestation-revocation-and-revocation-checking>|
-| [Topic 10] | ARF Annex 2 - Topic 10 - Issuing a PID or attestation to a Wallet Unit: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2310-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit>|
-| [Topic 12] | ARF Annex 2 - Topic 12 - Attestation Rulebooks, Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2312-topic-12-attestation-rulebooks>|
-| [Topic 20] | ARF Annex 2 - Strong User authentication for electronic payments, Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2320-topic-20-strong-user-authentication-for-electronic-payments>|
-| [W3C VCDM v2.0] | Sporny, M. *et al,* Verifiable Credentials Data Model v2.0, W3C Recommendation.  |
+| [OpenID4VCI] | Lodderstedt, T. *et al,* OpenID for Verifiable Credential Issuance, OpenID Foundation. Available: <https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html> |
+| [OpenID4VP] | Terbu, O. *et al,* OpenID for Verifiable Presentations, OpenID Foundation (includes the Digital Credentials Query Language, DCQL). Available: <https://openid.net/specs/openid-4-verifiable-presentations-1_0.html> |
+| [RFC 2119] | RFC 2119 - Key words for use in RFCs to Indicate Requirement Levels, S. Bradner, March 1997 |
+| [RFC 2397] | RFC 2397 - The "data" URL scheme, L. Masinter, August 1998 |
+| [RFC 7519] | RFC 7519 - JSON Web Token (JWT), M. Jones et al., May 2015 |
+| [RFC 7800] | RFC 7800 - Proof-of-Possession Key Semantics for JSON Web Tokens (JWTs), M. Jones et al., April 2016 |
+| [SD-JWT VC] | SD-JWT-based Verifiable Credentials (SD-JWT VC). Available: <https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/> |
+| [Topic 7] | ARF Annex 2 - Topic 7 - Attestation revocation and revocation checking Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a237-topic-7-attestation-revocation-and-revocation-checking> |
+| [Topic 10] | ARF Annex 2 - Topic 10 - Issuing a PID or attestation to a Wallet Unit: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2310-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit> |
+| [Topic 12] | ARF Annex 2 - Topic 12 - Attestation Rulebooks, Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2312-topic-12-attestation-rulebooks> |
+| [Topic 20] | ARF Annex 2 - Strong User authentication for electronic payments, Available: <https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/latest/annexes/annex-2/annex-2-high-level-requirements/#a2320-topic-20-strong-user-authentication-for-electronic-payments> |
+| [TS12] | TS12 - Electronic Payments SCA Implementation with Wallet, European Commission. Available: <https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts12-electronic-payments-SCA-implementation-with-wallet.md> |
+| [W3C Digital Credentials API] | W3C Digital Credentials, W3C Working Draft. Available: <https://www.w3.org/TR/digital-credentials/> |


### PR DESCRIPTION
## Summary

This PR introduces the WE BUILD attestation rulebook for **SCA-Card (DPC)**, the card-level SUA attestation described in [TS12], representing a digitised payment card as a verifiable credential (Digital Payment Credential) for payment authentication in remote commerce. The data model is derived from the EMVCo Digital Payment Credential specification and adapted to the WE BUILD SCA attestation family (rb-sca-user, rb-sca-iban).

## What is included

- `rulebooks/rb-sca-card-dpc/README.md` - the rulebook, following the WE BUILD template v1.1
- `data-schemas/sd-jwt/sca-card-dpc-sd-jwt.json` + sample - JSON Schema (draft 2020-12) for the resolved SD-JWT VC claim set
- `data-schemas/display/sca-card-dpc-display-meta.schema.json` + sample - JSON Schema for the unsigned display meta-data object (new `data-schemas/display/` folder)

## Key design decisions

- **Data minimisation:** the signed payload carries only `credential_id`, `network`, and an optional opaque `card_id` (never the PAN, BIN, or last four digits). All presentation data (card type, last four, alias, themed card art, issuer/co-brand/network branding) travels in a separate unsigned display meta-data object delivered in the OpenID4VCI `display` array, and is never presented to a Verifier.
- **No `sub` claim:** unlike the sibling SCA attestations, the credential is identified by `credential_id`; the source model has no subject identifier.
- **VCT hierarchy:** issuer-specific VCT extends `https://webuildconsortium.eu/sca/sca-card-dpc/1.0`, which extends the base SCA type `https://webuildconsortium.eu/sca/1.0`, protected by `extends#integrity`, with x.y versioning.
- **SD-JWT VC only:** the mdoc (ISO/IEC 18013-5) and W3C VCDM encodings are not supported; all use cases are online remote-commerce flows. All card claims are selectively disclosable.
- **Usage:** online OID4VP presentation with [TS12] transaction data ("sign what you see"); device-bound at AVA_VAN.4 or higher with a unique holder binding key per credential instance; PID verification not required. Worked SD-JWT examples and DCQL queries cover the known-credential and guest-checkout selection patterns.
- **Wallet display handling:** normative rules for theme selection with DEFAULT fallback, HTTPS and RFC 2397 Data URL image support, and privacy-preserving image fetching.
- **Legal category:** fixed to `non-qualified-EAA`.
- **Long-lived attestation**, aligned with the lifecycleed card.

## Deferred in this first draft

- **Revocation mechanism: TBD** (Chapter 6)
- **Trust anchor mechanism: TBD** (Chapter 5)
- **Co-badged cards: out of scope** - the EMVCo per-badgadopted in a future version (Section 2.1)

## Validation

Both schemas are valid JSON Schema and both samples valiworkflow checks (schema validity, sample conformance,sample coverage per folder) have been run locally, including for the new `data-schemas/display/` folder.

Closes #101     